### PR TITLE
add require forwardable

### DIFF
--- a/lib/queue-bus.rb
+++ b/lib/queue-bus.rb
@@ -1,4 +1,5 @@
 require "queue_bus/version"
+require "forwardable"
 
 module QueueBus
 


### PR DESCRIPTION
Solves `NameError: uninitialized constant Forwardable` issue https://github.com/queue-bus/queue-bus/issues/5
@bleonard 