### PR TITLE
Converts all should syntax to expect

### DIFF
--- a/spec/adapter_spec.rb
+++ b/spec/adapter_spec.rb
@@ -3,12 +3,12 @@ require 'spec_helper'
 describe "adapter is set" do
   it "should call it's enabled! method on init" do
     QueueBus.send(:reset)
-    adapter_under_test_class.any_instance.should_receive(:enabled!)
+    expect_any_instance_of(adapter_under_test_class).to receive(:enabled!)
     instance = adapter_under_test_class.new
     QueueBus.send(:reset)
   end
 
   it "should be defaulting to Data from spec_helper" do
-    QueueBus.adapter.is_a?(adapter_under_test_class).should == true
+    expect(QueueBus.adapter.is_a?(adapter_under_test_class)).to eq(true)
   end
 end

--- a/spec/config_spec.rb
+++ b/spec/config_spec.rb
@@ -10,51 +10,51 @@ end
 
 describe "QueueBus config" do
   it "should set the default app key" do
-    QueueBus.default_app_key.should == nil
+    expect(QueueBus.default_app_key).to eq(nil)
 
     QueueBus.default_app_key = "my_app"
-    QueueBus.default_app_key.should == "my_app"
+    expect(QueueBus.default_app_key).to eq("my_app")
 
     QueueBus.default_app_key = "something here"
-    QueueBus.default_app_key.should == "something_here"
+    expect(QueueBus.default_app_key).to eq("something_here")
   end
 
   it "should set the default queue" do
-    QueueBus.default_queue.should == nil
+    expect(QueueBus.default_queue).to eq(nil)
 
     QueueBus.default_queue = "my_queue"
-    QueueBus.default_queue.should == "my_queue"
+    expect(QueueBus.default_queue).to eq("my_queue")
   end
 
   it "should set the local mode" do
-    QueueBus.local_mode.should == nil
+    expect(QueueBus.local_mode).to eq(nil)
     QueueBus.local_mode = :standalone
-    QueueBus.local_mode.should == :standalone
+    expect(QueueBus.local_mode).to eq(:standalone)
   end
 
   it "should set the hostname" do
-    QueueBus.hostname.should_not == nil
+    expect(QueueBus.hostname).not_to eq(nil)
     QueueBus.hostname = "whatever"
-    QueueBus.hostname.should == "whatever"
+    expect(QueueBus.hostname).to eq("whatever")
   end
 
   it "should set before_publish callback" do
     QueueBus.before_publish = lambda {|attributes| 42 }
-    QueueBus.before_publish_callback({}).should == 42
+    expect(QueueBus.before_publish_callback({})).to eq(42)
   end
 
 
   it "should use the default Redis connection" do
-    QueueBus.redis { |redis| redis }.should_not eq(nil)
+    expect(QueueBus.redis { |redis| redis }).not_to eq(nil)
   end
 
   it "should default to given adapter" do
-    QueueBus.adapter.is_a?(adapter_under_test_class).should == true
+    expect(QueueBus.adapter.is_a?(adapter_under_test_class)).to eq(true)
 
     # and should raise if already set
-    lambda {
+    expect {
       QueueBus.adapter = :data
-    }.should raise_error
+    }.to raise_error
   end
 
   context "with a fresh load" do
@@ -64,18 +64,18 @@ describe "QueueBus config" do
 
     it "should be able to be set to resque" do
       QueueBus.adapter = adapter_under_test_symbol
-      QueueBus.adapter.is_a?(adapter_under_test_class).should == true
+      expect(QueueBus.adapter.is_a?(adapter_under_test_class)).to eq(true)
 
       # and should raise if already set
-      lambda {
+      expect {
         QueueBus.adapter = :data
-      }.should raise_error
+      }.to raise_error
     end
 
     it "should be able to be set to something else" do
 
       QueueBus.adapter = :test_one
-      QueueBus.adapter.is_a?(QueueBus::Adapters::TestOne).should == true
+      expect(QueueBus.adapter.is_a?(QueueBus::Adapters::TestOne)).to eq(true)
     end
   end
 

--- a/spec/dispatch_spec.rb
+++ b/spec/dispatch_spec.rb
@@ -3,7 +3,7 @@ require 'spec_helper'
 module QueueBus
   describe Dispatch do
     it "should not start with any applications" do
-      Dispatch.new("d").subscriptions.size.should == 0
+      expect(Dispatch.new("d").subscriptions.size).to eq(0)
     end
     
     it "should register code to run and execute it" do
@@ -12,19 +12,19 @@ module QueueBus
         Runner1.run(attrs)
       end
       sub = dispatch.subscriptions.key("my_event")
-      sub.send(:executor).is_a?(Proc).should == true
+      expect(sub.send(:executor).is_a?(Proc)).to eq(true)
 
-      Runner.value.should == 0
+      expect(Runner.value).to eq(0)
       dispatch.execute("my_event", {"bus_event_type" => "my_event", "ok" => true})
-      Runner1.value.should == 1
-      Runner1.attributes.should == {"bus_event_type" => "my_event", "ok" => true}
+      expect(Runner1.value).to eq(1)
+      expect(Runner1.attributes).to eq({"bus_event_type" => "my_event", "ok" => true})
       
     end
     
     it "should not crash if not there" do
-      lambda {
+      expect {
         Dispatch.new("d").execute("fdkjh", "bus_event_type" => "fdkjh")
-      }.should_not raise_error
+      }.not_to raise_error
     end
     
     describe "Top Level" do
@@ -49,24 +49,24 @@ module QueueBus
        end
        
       it "should register and run" do
-        Runner2.value.should == 0
+        expect(Runner2.value).to eq(0)
         QueueBus.dispatcher_execute("testit", "event2", "bus_event_type" => "event2")
-        Runner2.value.should == 1
+        expect(Runner2.value).to eq(1)
         QueueBus.dispatcher_execute("testit", "event1", "bus_event_type" => "event1")
-        Runner2.value.should == 2
+        expect(Runner2.value).to eq(2)
         QueueBus.dispatcher_execute("testit", "event1", "bus_event_type" => "event1")
-        Runner2.value.should == 3
+        expect(Runner2.value).to eq(3)
       end
       
       it "should return the subscriptions" do
         dispatcher = QueueBus.dispatcher_by_key("testit")
         subs = dispatcher.subscriptions.all
         tuples = subs.collect{ |sub| [sub.key, sub.queue_name]}
-        tuples.should =~ [  ["event1", "testit_default"],
+        expect(tuples).to match_array([  ["event1", "testit_default"],
                             ["event2", "testit_default"],
                             ["event3", "testit_high"],
                             [ "(?-mix:^patt.+ern)", "testit_low"]
-                         ]
+                         ])
       end
     
     end

--- a/spec/driver_spec.rb
+++ b/spec/driver_spec.rb
@@ -16,21 +16,21 @@ module QueueBus
 
     describe ".subscription_matches" do
       it "return empty array when none" do
-        Driver.subscription_matches("bus_event_type" => "else").collect{|s| [s.app_key, s.key, s.queue_name, s.class_name]}.should == []
-        Driver.subscription_matches("bus_event_type" => "event").collect{|s| [s.app_key, s.key, s.queue_name, s.class_name]}.should == []
+        expect(Driver.subscription_matches("bus_event_type" => "else").collect{|s| [s.app_key, s.key, s.queue_name, s.class_name]}).to eq([])
+        expect(Driver.subscription_matches("bus_event_type" => "event").collect{|s| [s.app_key, s.key, s.queue_name, s.class_name]}).to eq([])
       end
       it "should return a match" do
-        Driver.subscription_matches("bus_event_type" => "event1").collect{|s| [s.app_key, s.key, s.queue_name, s.class_name]}.should =~ [["app1", "event1", "default", "::QueueBus::Rider"]]
-        Driver.subscription_matches("bus_event_type" => "event6").collect{|s| [s.app_key, s.key, s.queue_name, s.class_name]}.should =~ [["app3", "event6", "default", "::QueueBus::Rider"]]
+        expect(Driver.subscription_matches("bus_event_type" => "event1").collect{|s| [s.app_key, s.key, s.queue_name, s.class_name]}).to match_array([["app1", "event1", "default", "::QueueBus::Rider"]])
+        expect(Driver.subscription_matches("bus_event_type" => "event6").collect{|s| [s.app_key, s.key, s.queue_name, s.class_name]}).to match_array([["app3", "event6", "default", "::QueueBus::Rider"]])
       end
       it "should match multiple apps" do
-        Driver.subscription_matches("bus_event_type" => "event2").collect{|s| [s.app_key, s.key, s.queue_name, s.class_name]}.should =~ [["app1", "event2", "default", "::QueueBus::Rider"], ["app2", "event2", "other", "::QueueBus::Rider"]]
+        expect(Driver.subscription_matches("bus_event_type" => "event2").collect{|s| [s.app_key, s.key, s.queue_name, s.class_name]}).to match_array([["app1", "event2", "default", "::QueueBus::Rider"], ["app2", "event2", "other", "::QueueBus::Rider"]])
       end
       it "should match multiple apps with patterns" do
-        Driver.subscription_matches("bus_event_type" => "event4").collect{|s| [s.app_key, s.key, s.queue_name, s.class_name]}.should =~ [["app3", "event[45]", "default", "::QueueBus::Rider"], ["app2", "event4", "more", "::QueueBus::Rider"]]
+        expect(Driver.subscription_matches("bus_event_type" => "event4").collect{|s| [s.app_key, s.key, s.queue_name, s.class_name]}).to match_array([["app3", "event[45]", "default", "::QueueBus::Rider"], ["app2", "event4", "more", "::QueueBus::Rider"]])
       end
       it "should match multiple events in same app" do
-        Driver.subscription_matches("bus_event_type" => "event5").collect{|s| [s.app_key, s.key, s.queue_name, s.class_name]}.should =~ [["app3", "event[45]", "default", "::QueueBus::Rider"], ["app3", "event5", "default", "::QueueBus::Rider"]]
+        expect(Driver.subscription_matches("bus_event_type" => "event5").collect{|s| [s.app_key, s.key, s.queue_name, s.class_name]}).to match_array([["app3", "event[45]", "default", "::QueueBus::Rider"], ["app3", "event5", "default", "::QueueBus::Rider"]])
       end
     end
 
@@ -38,48 +38,48 @@ module QueueBus
       let(:attributes) { {"x" => "y", "bus_class_proxy" => "ResqueBus::Driver"} }
 
       before(:each) do
-        QueueBus.redis { |redis| redis.smembers("queues") }.should == []
-        QueueBus.redis { |redis| redis.lpop("queue:app1_default") }.should be_nil
-        QueueBus.redis { |redis| redis.lpop("queue:app2_default") }.should be_nil
-        QueueBus.redis { |redis| redis.lpop("queue:app3_default") }.should be_nil
+        expect(QueueBus.redis { |redis| redis.smembers("queues") }).to eq([])
+        expect(QueueBus.redis { |redis| redis.lpop("queue:app1_default") }).to be_nil
+        expect(QueueBus.redis { |redis| redis.lpop("queue:app2_default") }).to be_nil
+        expect(QueueBus.redis { |redis| redis.lpop("queue:app3_default") }).to be_nil
       end
 
       it "should do nothing when empty" do
         Driver.perform(attributes.merge("bus_event_type" => "else"))
-        QueueBus.redis { |redis| redis.smembers("queues") }.should == []
+        expect(QueueBus.redis { |redis| redis.smembers("queues") }).to eq([])
       end
 
       it "should queue up the riders in redis" do
-        QueueBus.redis { |redis| redis.lpop("queue:app1_default") }.should be_nil
+        expect(QueueBus.redis { |redis| redis.lpop("queue:app1_default") }).to be_nil
         Driver.perform(attributes.merge("bus_event_type" => "event1"))
-        QueueBus.redis { |redis| redis.smembers("queues") }.should =~ ["default"]
+        expect(QueueBus.redis { |redis| redis.smembers("queues") }).to match_array(["default"])
 
         hash = JSON.parse(QueueBus.redis { |redis| redis.lpop("queue:default") })
-        hash["class"].should == "QueueBus::Worker"
-        hash["args"].size.should == 1
-        JSON.parse(hash["args"].first).should == {"bus_rider_app_key"=>"app1", "x" => "y", "bus_event_type" => "event1", "bus_rider_sub_key"=>"event1", "bus_rider_queue" => "default"}.merge(bus_attrs)
+        expect(hash["class"]).to eq("QueueBus::Worker")
+        expect(hash["args"].size).to eq(1)
+        expect(JSON.parse(hash["args"].first)).to eq({"bus_rider_app_key"=>"app1", "x" => "y", "bus_event_type" => "event1", "bus_rider_sub_key"=>"event1", "bus_rider_queue" => "default"}.merge(bus_attrs))
       end
 
       it "should queue up to multiple" do
         Driver.perform(attributes.merge("bus_event_type" => "event4"))
-        QueueBus.redis { |redis| redis.smembers("queues") }.should =~ ["default", "more"]
+        expect(QueueBus.redis { |redis| redis.smembers("queues") }).to match_array(["default", "more"])
 
         hash = JSON.parse(QueueBus.redis { |redis| redis.lpop("queue:more") })
-        hash["class"].should == "QueueBus::Worker"
-        hash["args"].size.should == 1
-        JSON.parse(hash["args"].first).should == {"bus_rider_app_key"=>"app2", "x" => "y", "bus_event_type" => "event4", "bus_rider_sub_key"=>"event4", "bus_rider_queue" => "more"}.merge(bus_attrs)
+        expect(hash["class"]).to eq("QueueBus::Worker")
+        expect(hash["args"].size).to eq(1)
+        expect(JSON.parse(hash["args"].first)).to eq({"bus_rider_app_key"=>"app2", "x" => "y", "bus_event_type" => "event4", "bus_rider_sub_key"=>"event4", "bus_rider_queue" => "more"}.merge(bus_attrs))
 
         hash = JSON.parse(QueueBus.redis { |redis| redis.lpop("queue:default") })
-        hash["class"].should == "QueueBus::Worker"
-        hash["args"].size.should == 1
-        JSON.parse(hash["args"].first).should == {"bus_rider_app_key"=>"app3", "x" => "y", "bus_event_type" => "event4", "bus_rider_sub_key"=>"event[45]", "bus_rider_queue" => "default"}.merge(bus_attrs)
+        expect(hash["class"]).to eq("QueueBus::Worker")
+        expect(hash["args"].size).to eq(1)
+        expect(JSON.parse(hash["args"].first)).to eq({"bus_rider_app_key"=>"app3", "x" => "y", "bus_event_type" => "event4", "bus_rider_sub_key"=>"event[45]", "bus_rider_queue" => "default"}.merge(bus_attrs))
       end
 
       it "should queue up to the same" do
         Driver.perform(attributes.merge("bus_event_type" => "event5"))
-        QueueBus.redis { |redis| redis.smembers("queues") }.should =~ ["default"]
+        expect(QueueBus.redis { |redis| redis.smembers("queues") }).to match_array(["default"])
 
-        QueueBus.redis { |redis| redis.llen("queue:default") }.should == 2
+        expect(QueueBus.redis { |redis| redis.llen("queue:default") }).to eq(2)
 
         pop1 = JSON.parse(QueueBus.redis { |redis| redis.lpop("queue:default") })
         pop2 = JSON.parse(QueueBus.redis { |redis| redis.lpop("queue:default") })
@@ -98,11 +98,11 @@ module QueueBus
           args2 = pargs1
         end
 
-        hash1["class"].should == "QueueBus::Worker"
-        args1.should == {"bus_rider_app_key"=>"app3", "x" => "y", "bus_event_type" => "event5", "bus_rider_sub_key"=>"event5", "bus_rider_queue" => "default"}.merge(bus_attrs)
+        expect(hash1["class"]).to eq("QueueBus::Worker")
+        expect(args1).to eq({"bus_rider_app_key"=>"app3", "x" => "y", "bus_event_type" => "event5", "bus_rider_sub_key"=>"event5", "bus_rider_queue" => "default"}.merge(bus_attrs))
 
-        hash2["class"].should == "QueueBus::Worker"
-        args2.should == {"bus_rider_app_key"=>"app3", "x" => "y", "bus_event_type" => "event5", "bus_rider_sub_key"=>"event[45]", "bus_rider_queue" => "default"}.merge(bus_attrs)
+        expect(hash2["class"]).to eq("QueueBus::Worker")
+        expect(args2).to eq({"bus_rider_app_key"=>"app3", "x" => "y", "bus_event_type" => "event5", "bus_rider_sub_key"=>"event[45]", "bus_rider_queue" => "default"}.merge(bus_attrs))
       end
     end
   end

--- a/spec/heartbeat_spec.rb
+++ b/spec/heartbeat_spec.rb
@@ -20,7 +20,7 @@ module QueueBus
     
     it "should publish the current time once" do
       Timecop.freeze "12/12/2013 12:01:19" do
-        QueueBus.should_receive(:publish).with("heartbeat_minutes", now_attributes)
+        expect(QueueBus).to receive(:publish).with("heartbeat_minutes", now_attributes)
         Heartbeat.perform
       end
       
@@ -31,12 +31,12 @@ module QueueBus
     
     it "should publish a minute later" do
       Timecop.freeze "12/12/2013 12:01:19" do
-        QueueBus.should_receive(:publish).with("heartbeat_minutes", now_attributes)
+        expect(QueueBus).to receive(:publish).with("heartbeat_minutes", now_attributes)
         Heartbeat.perform
       end
       
       Timecop.freeze "12/12/2013 12:02:01" do
-        QueueBus.should_receive(:publish).with("heartbeat_minutes", now_attributes)
+        expect(QueueBus).to receive(:publish).with("heartbeat_minutes", now_attributes)
         Heartbeat.perform
       end
     end

--- a/spec/integration_spec.rb
+++ b/spec/integration_spec.rb
@@ -6,15 +6,15 @@ module QueueBus
       write1 = Subscription.new("default", "key1", "MyClass1", {"bus_event_type" => "event_one"})
       write2 = Subscription.new("else_ok", "key2", "MyClass2", {"bus_event_type" => /^[ab]here/})  #regex
     
-      write1.matches?("bus_event_type" => "event_one").should  == true
-      write1.matches?("bus_event_type" => "event_one1").should == false
-      write1.matches?("bus_event_type" => "aevent_one").should == false
+      expect(write1.matches?("bus_event_type" => "event_one")).to  eq(true)
+      expect(write1.matches?("bus_event_type" => "event_one1")).to eq(false)
+      expect(write1.matches?("bus_event_type" => "aevent_one")).to eq(false)
       
-      write2.matches?("bus_event_type" => "ahere").should == true
-      write2.matches?("bus_event_type" => "bhere").should == true
-      write2.matches?("bus_event_type" => "qhere").should == false
-      write2.matches?("bus_event_type" => "abhere").should == false
-      write2.matches?("bus_event_type" => "[ab]here").should == false
+      expect(write2.matches?("bus_event_type" => "ahere")).to eq(true)
+      expect(write2.matches?("bus_event_type" => "bhere")).to eq(true)
+      expect(write2.matches?("bus_event_type" => "qhere")).to eq(false)
+      expect(write2.matches?("bus_event_type" => "abhere")).to eq(false)
+      expect(write2.matches?("bus_event_type" => "[ab]here")).to eq(false)
     
       write = SubscriptionList.new
       write.add(write1)
@@ -27,26 +27,26 @@ module QueueBus
       app = Application.new("test")
       read = app.send(:subscriptions)
     
-      read.size.should == 2
+      expect(read.size).to eq(2)
       read1 = read.key("key1")
       read2 = read.key("key2")
-      read1.should_not be_nil
-      read2.should_not be_nil
+      expect(read1).not_to be_nil
+      expect(read2).not_to be_nil
       
-      read1.queue_name.should == "default"
-      read1.class_name.should == "MyClass1"
-      read2.queue_name.should == "else_ok"
-      read2.class_name.should == "MyClass2"
+      expect(read1.queue_name).to eq("default")
+      expect(read1.class_name).to eq("MyClass1")
+      expect(read2.queue_name).to eq("else_ok")
+      expect(read2.class_name).to eq("MyClass2")
       
-      read1.matches?("bus_event_type" => "event_one").should  == true
-      read1.matches?("bus_event_type" => "event_one1").should == false
-      read1.matches?("bus_event_type" => "aevent_one").should == false
+      expect(read1.matches?("bus_event_type" => "event_one")).to  eq(true)
+      expect(read1.matches?("bus_event_type" => "event_one1")).to eq(false)
+      expect(read1.matches?("bus_event_type" => "aevent_one")).to eq(false)
       
-      read2.matches?("bus_event_type" => "ahere").should == true
-      read2.matches?("bus_event_type" => "bhere").should == true
-      read2.matches?("bus_event_type" => "qhere").should == false
-      read2.matches?("bus_event_type" => "abhere").should == false
-      read2.matches?("bus_event_type" => "[ab]here").should == false
+      expect(read2.matches?("bus_event_type" => "ahere")).to eq(true)
+      expect(read2.matches?("bus_event_type" => "bhere")).to eq(true)
+      expect(read2.matches?("bus_event_type" => "qhere")).to eq(false)
+      expect(read2.matches?("bus_event_type" => "abhere")).to eq(false)
+      expect(read2.matches?("bus_event_type" => "[ab]here")).to eq(false)
       
     end
   end

--- a/spec/matcher_spec.rb
+++ b/spec/matcher_spec.rb
@@ -4,140 +4,140 @@ module QueueBus
   describe Matcher do
     it "should already return false on empty filters" do
       matcher = Matcher.new({})
-      matcher.matches?({}).should  == false
-      matcher.matches?(nil).should  == false
-      matcher.matches?("name" => "val").should == false
+      expect(matcher.matches?({})).to  eq(false)
+      expect(matcher.matches?(nil)).to  eq(false)
+      expect(matcher.matches?("name" => "val")).to eq(false)
     end
 
     it "should not crash if nil inputs" do
       matcher = Matcher.new("name" => "val")
-      matcher.matches?(nil).should == false
+      expect(matcher.matches?(nil)).to eq(false)
     end
 
     it "string filter to/from redis" do
       matcher = Matcher.new("name" => "val")
-      matcher.matches?("name" => "val").should   == true
-      matcher.matches?("name" => " val").should  == false
-      matcher.matches?("name" => "zval").should  == false
+      expect(matcher.matches?("name" => "val")).to   eq(true)
+      expect(matcher.matches?("name" => " val")).to  eq(false)
+      expect(matcher.matches?("name" => "zval")).to  eq(false)
     end
 
     it "regex filter" do
       matcher = Matcher.new("name" => /^[cb]a+t/)
-      matcher.matches?("name" => "cat").should == true
-      matcher.matches?("name" => "bat").should == true
-      matcher.matches?("name" => "caaaaat").should == true
-      matcher.matches?("name" => "ct").should == false
-      matcher.matches?("name" => "bcat").should == false
+      expect(matcher.matches?("name" => "cat")).to eq(true)
+      expect(matcher.matches?("name" => "bat")).to eq(true)
+      expect(matcher.matches?("name" => "caaaaat")).to eq(true)
+      expect(matcher.matches?("name" => "ct")).to eq(false)
+      expect(matcher.matches?("name" => "bcat")).to eq(false)
     end
 
     it "present filter" do
       matcher = Matcher.new("name" => :present)
-      matcher.matches?("name" => "").should == false
-      matcher.matches?("name" => "cat").should == true
-      matcher.matches?("name" => "bear").should == true
-      matcher.matches?("other" => "bear").should == false
+      expect(matcher.matches?("name" => "")).to eq(false)
+      expect(matcher.matches?("name" => "cat")).to eq(true)
+      expect(matcher.matches?("name" => "bear")).to eq(true)
+      expect(matcher.matches?("other" => "bear")).to eq(false)
     end
 
     it "blank filter" do
       matcher = Matcher.new("name" => :blank)
-      matcher.matches?("name" => nil).should == true
-      matcher.matches?("other" => "bear").should == true
-      matcher.matches?("name" => "").should == true
-      matcher.matches?("name" => "  ").should == true
-      matcher.matches?("name" => "bear").should == false
-      matcher.matches?("name" => "   s ").should == false
+      expect(matcher.matches?("name" => nil)).to eq(true)
+      expect(matcher.matches?("other" => "bear")).to eq(true)
+      expect(matcher.matches?("name" => "")).to eq(true)
+      expect(matcher.matches?("name" => "  ")).to eq(true)
+      expect(matcher.matches?("name" => "bear")).to eq(false)
+      expect(matcher.matches?("name" => "   s ")).to eq(false)
     end
 
     it "nil filter" do
       matcher = Matcher.new("name" => :nil)
-      matcher.matches?("name" => nil).should == true
-      matcher.matches?("other" => "bear").should == true
-      matcher.matches?("name" => "").should == false
-      matcher.matches?("name" => "  ").should == false
-      matcher.matches?("name" => "bear").should == false
+      expect(matcher.matches?("name" => nil)).to eq(true)
+      expect(matcher.matches?("other" => "bear")).to eq(true)
+      expect(matcher.matches?("name" => "")).to eq(false)
+      expect(matcher.matches?("name" => "  ")).to eq(false)
+      expect(matcher.matches?("name" => "bear")).to eq(false)
     end
 
     it "key filter" do
       matcher = Matcher.new("name" => :key)
-      matcher.matches?("name" => nil).should == true
-      matcher.matches?("other" => "bear").should == false
-      matcher.matches?("name" => "").should == true
-      matcher.matches?("name" => "  ").should == true
-      matcher.matches?("name" => "bear").should == true
+      expect(matcher.matches?("name" => nil)).to eq(true)
+      expect(matcher.matches?("other" => "bear")).to eq(false)
+      expect(matcher.matches?("name" => "")).to eq(true)
+      expect(matcher.matches?("name" => "  ")).to eq(true)
+      expect(matcher.matches?("name" => "bear")).to eq(true)
     end
 
     it "empty filter" do
       matcher = Matcher.new("name" => :empty)
-      matcher.matches?("name" => nil).should == false
-      matcher.matches?("other" => "bear").should == false
-      matcher.matches?("name" => "").should == true
-      matcher.matches?("name" => "  ").should == false
-      matcher.matches?("name" => "bear").should == false
-      matcher.matches?("name" => "   s ").should == false
+      expect(matcher.matches?("name" => nil)).to eq(false)
+      expect(matcher.matches?("other" => "bear")).to eq(false)
+      expect(matcher.matches?("name" => "")).to eq(true)
+      expect(matcher.matches?("name" => "  ")).to eq(false)
+      expect(matcher.matches?("name" => "bear")).to eq(false)
+      expect(matcher.matches?("name" => "   s ")).to eq(false)
     end
 
     it "value filter" do
       matcher = Matcher.new("name" => :value)
-      matcher.matches?("name" => nil).should == false
-      matcher.matches?("other" => "bear").should == false
-      matcher.matches?("name" => "").should == true
-      matcher.matches?("name" => "  ").should == true
-      matcher.matches?("name" => "bear").should == true
-      matcher.matches?("name" => "   s ").should == true
+      expect(matcher.matches?("name" => nil)).to eq(false)
+      expect(matcher.matches?("other" => "bear")).to eq(false)
+      expect(matcher.matches?("name" => "")).to eq(true)
+      expect(matcher.matches?("name" => "  ")).to eq(true)
+      expect(matcher.matches?("name" => "bear")).to eq(true)
+      expect(matcher.matches?("name" => "   s ")).to eq(true)
     end
 
     it "multiple filters" do
       matcher = Matcher.new("name" => /^[cb]a+t/, "state" => "sleeping")
-      matcher.matches?("state" => "sleeping", "name" => "cat").should  == true
-      matcher.matches?("state" => "awake", "name" => "cat").should     == false
-      matcher.matches?("state" => "sleeping", "name" => "bat").should  == true
-      matcher.matches?("state" => "sleeping", "name" => "bear").should == false
-      matcher.matches?("state" => "awake", "name" => "bear").should    == false
+      expect(matcher.matches?("state" => "sleeping", "name" => "cat")).to  eq(true)
+      expect(matcher.matches?("state" => "awake", "name" => "cat")).to     eq(false)
+      expect(matcher.matches?("state" => "sleeping", "name" => "bat")).to  eq(true)
+      expect(matcher.matches?("state" => "sleeping", "name" => "bear")).to eq(false)
+      expect(matcher.matches?("state" => "awake", "name" => "bear")).to    eq(false)
     end
 
     it "regex should go back and forth into redis" do
       matcher = Matcher.new("name" => /^[cb]a+t/)
-      matcher.matches?("name" => "cat").should == true
-      matcher.matches?("name" => "bat").should == true
-      matcher.matches?("name" => "caaaaat").should == true
-      matcher.matches?("name" => "ct").should == false
-      matcher.matches?("name" => "bcat").should == false
+      expect(matcher.matches?("name" => "cat")).to eq(true)
+      expect(matcher.matches?("name" => "bat")).to eq(true)
+      expect(matcher.matches?("name" => "caaaaat")).to eq(true)
+      expect(matcher.matches?("name" => "ct")).to eq(false)
+      expect(matcher.matches?("name" => "bcat")).to eq(false)
 
       QueueBus.redis { |redis| redis.set("temp1", QueueBus::Util.encode(matcher.to_redis) ) }
       redis = QueueBus.redis { |redis| redis.get("temp1") }
       matcher = Matcher.new(QueueBus::Util.decode(redis))
-      matcher.matches?("name" => "cat").should == true
-      matcher.matches?("name" => "bat").should == true
-      matcher.matches?("name" => "caaaaat").should == true
-      matcher.matches?("name" => "ct").should == false
-      matcher.matches?("name" => "bcat").should == false
+      expect(matcher.matches?("name" => "cat")).to eq(true)
+      expect(matcher.matches?("name" => "bat")).to eq(true)
+      expect(matcher.matches?("name" => "caaaaat")).to eq(true)
+      expect(matcher.matches?("name" => "ct")).to eq(false)
+      expect(matcher.matches?("name" => "bcat")).to eq(false)
 
       QueueBus.redis { |redis| redis.set("temp2", QueueBus::Util.encode(matcher.to_redis) ) }
       redis = QueueBus.redis { |redis| redis.get("temp2") }
       matcher = Matcher.new(QueueBus::Util.decode(redis))
-      matcher.matches?("name" => "cat").should == true
-      matcher.matches?("name" => "bat").should == true
-      matcher.matches?("name" => "caaaaat").should == true
-      matcher.matches?("name" => "ct").should == false
-      matcher.matches?("name" => "bcat").should == false
+      expect(matcher.matches?("name" => "cat")).to eq(true)
+      expect(matcher.matches?("name" => "bat")).to eq(true)
+      expect(matcher.matches?("name" => "caaaaat")).to eq(true)
+      expect(matcher.matches?("name" => "ct")).to eq(false)
+      expect(matcher.matches?("name" => "bcat")).to eq(false)
     end
 
     it "special value should go back and forth into redis" do
       matcher = Matcher.new("name" => :blank)
-      matcher.matches?("name" => "cat").should == false
-      matcher.matches?("name" => "").should    == true
+      expect(matcher.matches?("name" => "cat")).to eq(false)
+      expect(matcher.matches?("name" => "")).to    eq(true)
 
       QueueBus.redis { |redis| redis.set("temp1", QueueBus::Util.encode(matcher.to_redis) ) }
       redis= QueueBus.redis { |redis| redis.get("temp1") }
       matcher = Matcher.new(QueueBus::Util.decode(redis))
-      matcher.matches?("name" => "cat").should == false
-      matcher.matches?("name" => "").should    == true
+      expect(matcher.matches?("name" => "cat")).to eq(false)
+      expect(matcher.matches?("name" => "")).to    eq(true)
 
       QueueBus.redis { |redis| redis.set("temp2", QueueBus::Util.encode(matcher.to_redis) ) }
       redis= QueueBus.redis { |redis| redis.get("temp2") }
       matcher = Matcher.new(QueueBus::Util.decode(redis))
-      matcher.matches?("name" => "cat").should == false
-      matcher.matches?("name" => "").should    == true
+      expect(matcher.matches?("name" => "cat")).to eq(false)
+      expect(matcher.matches?("name" => "")).to    eq(true)
     end
   end
 end

--- a/spec/publish_spec.rb
+++ b/spec/publish_spec.rb
@@ -4,7 +4,7 @@ describe "Publishing an event" do
 
   before(:each) do
     Timecop.freeze
-    QueueBus.stub(:generate_uuid).and_return("idfhlkj")
+    allow(QueueBus).to receive(:generate_uuid).and_return("idfhlkj")
   end
   after(:each) do
     Timecop.return
@@ -19,15 +19,15 @@ describe "Publishing an event" do
     event_name = "event_name"
 
     val = QueueBus.redis { |redis| redis.lpop("queue:bus_incoming") }
-    val.should == nil
+    expect(val).to eq(nil)
 
     QueueBus.publish(event_name, hash)
 
     val = QueueBus.redis { |redis| redis.lpop("queue:bus_incoming") }
     hash = JSON.parse(val)
-    hash["class"].should == "QueueBus::Worker"
-    hash["args"].size.should == 1
-    JSON.parse(hash["args"].first).should == {"bus_event_type" => event_name, "two"=>"here", "one"=>1, "id" => 12}.merge(bus_attrs)
+    expect(hash["class"]).to eq("QueueBus::Worker")
+    expect(hash["args"].size).to eq(1)
+    expect(JSON.parse(hash["args"].first)).to eq({"bus_event_type" => event_name, "two"=>"here", "one"=>1, "id" => 12}.merge(bus_attrs))
 
   end
 
@@ -36,15 +36,15 @@ describe "Publishing an event" do
     event_name = "event_name"
 
     val = QueueBus.redis { |redis| redis.lpop("queue:bus_incoming") }
-    val.should == nil
+    expect(val).to eq(nil)
 
     QueueBus.publish(event_name, hash)
 
     val = QueueBus.redis { |redis| redis.lpop("queue:bus_incoming") }
     hash = JSON.parse(val)
-    hash["class"].should == "QueueBus::Worker"
-    hash["args"].size.should == 1
-    JSON.parse(hash["args"].first).should == {"bus_event_type" => event_name, "two"=>"here", "one"=>1}.merge(bus_attrs).merge("bus_id" => 'app-given')
+    expect(hash["class"]).to eq("QueueBus::Worker")
+    expect(hash["args"].size).to eq(1)
+    expect(JSON.parse(hash["args"].first)).to eq({"bus_event_type" => event_name, "two"=>"here", "one"=>1}.merge(bus_attrs).merge("bus_id" => 'app-given'))
   end
 
   it "should add metadata via callback" do
@@ -58,7 +58,7 @@ describe "Publishing an event" do
     event_name = "event_name"
 
     val = QueueBus.redis { |redis| redis.lpop("queue:bus_incoming") }
-    val.should == nil
+    expect(val).to eq(nil)
 
     QueueBus.publish(event_name, hash)
 
@@ -66,33 +66,33 @@ describe "Publishing an event" do
     val = QueueBus.redis { |redis| redis.lpop("queue:bus_incoming") }
     hash = JSON.parse(val)
     att = JSON.parse(hash["args"].first)
-    att["mine"].should == 4
-    myval.should == 1
+    expect(att["mine"]).to eq(4)
+    expect(myval).to eq(1)
   end
 
   it "should set the timezone and locale if available" do
-    defined?(I18n).should be_nil
-    Time.respond_to?(:zone).should eq(false)
+    expect(defined?(I18n)).to be_nil
+    expect(Time.respond_to?(:zone)).to eq(false)
 
     stub_const("I18n", Class.new)
-    I18n.stub(:locale).and_return("jp")
+    allow(I18n).to receive(:locale).and_return("jp")
 
-    Time.stub(:zone).and_return(double('zone', :name => "EST"))
+    allow(Time).to receive(:zone).and_return(double('zone', :name => "EST"))
 
     hash = {:one => 1, "two" => "here", "bus_id" => "app-given" }
     event_name = "event_name"
 
     val = QueueBus.redis { |redis| redis.lpop("queue:bus_incoming") }
-    val.should == nil
+    expect(val).to eq(nil)
 
     QueueBus.publish(event_name, hash)
 
     val = QueueBus.redis { |redis| redis.lpop("queue:bus_incoming") }
     hash = JSON.parse(val)
-    hash["class"].should == "QueueBus::Worker"
+    expect(hash["class"]).to eq("QueueBus::Worker")
     att = JSON.parse(hash["args"].first)
-    att["bus_locale"].should == "jp"
-    att["bus_timezone"].should == "EST"
+    expect(att["bus_locale"]).to eq("jp")
+    expect(att["bus_timezone"]).to eq("EST")
   end
 
 end

--- a/spec/rider_spec.rb
+++ b/spec/rider_spec.rb
@@ -3,7 +3,7 @@ require 'spec_helper'
 module QueueBus
   describe Rider do
     it "should call execute" do
-      QueueBus.should_receive(:dispatcher_execute)
+      expect(QueueBus).to receive(:dispatcher_execute)
       Rider.perform("bus_rider_app_key" => "app", "bus_rider_sub_key" => "sub", "ok" => true, "bus_event_type" => "event_name")
     end
 
@@ -13,10 +13,10 @@ module QueueBus
           Runner1.run(attributes)
         end
       end
-      Runner1.value.should == 0
+      expect(Runner1.value).to eq(0)
       Rider.perform("bus_locale" => "en", "bus_timezone" => "PST", "bus_rider_app_key" => "r1", "bus_rider_sub_key" => "event_name", "ok" => true, "bus_event_type" => "event_name")
       Rider.perform("bus_rider_app_key" => "other", "bus_rider_sub_key" => "event_name", "ok" => true, "bus_event_type" => "event_name")
-      Runner1.value.should == 1
+      expect(Runner1.value).to eq(1)
     end
 
     it "should set the timezone and locale if present" do
@@ -26,12 +26,12 @@ module QueueBus
         end
       end
 
-      defined?(I18n).should be_nil
-      Time.respond_to?(:zone).should eq(false)
+      expect(defined?(I18n)).to be_nil
+      expect(Time.respond_to?(:zone)).to eq(false)
 
       stub_const("I18n", Class.new)
-      I18n.should_receive(:locale=).with("en")
-      Time.should_receive(:zone=).with("PST")
+      expect(I18n).to receive(:locale=).with("en")
+      expect(Time).to receive(:zone=).with("PST")
 
       Rider.perform("bus_locale" => "en", "bus_timezone" => "PST", "bus_rider_app_key" => "r1", "bus_rider_sub_key" => "event_name", "ok" => true, "bus_event_type" => "event_name")
     end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -48,10 +48,10 @@ end
 
 RSpec.configure do |config|
   config.mock_with :rspec do |c|
-    c.syntax = :should
+    c.syntax = :expect
   end
   config.expect_with :rspec do |c|
-    c.syntax = :should
+    c.syntax = :expect
   end
 
   config.before(:each) do

--- a/spec/subscriber_spec.rb
+++ b/spec/subscriber_spec.rb
@@ -70,111 +70,111 @@ require 'spec_helper'
     end
 
     it "should have the application" do
-      SubscriberTest1.app_key.should == "my_thing"
-      SubModule::SubscriberTest3.app_key.should == "sub_module"
-      SubModule::SubscriberTest4.app_key.should == "sub_module"
+      expect(SubscriberTest1.app_key).to eq("my_thing")
+      expect(SubModule::SubscriberTest3.app_key).to eq("sub_module")
+      expect(SubModule::SubscriberTest4.app_key).to eq("sub_module")
     end
 
     it "should be able to transform the attributes" do
       dispatcher = QueueBus.dispatcher_by_key("test2")
       all = dispatcher.subscriptions.all
-      all.size.should == 1
+      expect(all.size).to eq(1)
 
       sub = all.first
-      sub.queue_name.should == "test2_default"
-      sub.class_name.should == "SubscriberTest2"
-      sub.key.should == "SubscriberTest2.test2"
-      sub.matcher.filters.should == {"value"=>"bus_special_value_present"}
+      expect(sub.queue_name).to eq("test2_default")
+      expect(sub.class_name).to eq("SubscriberTest2")
+      expect(sub.key).to eq("SubscriberTest2.test2")
+      expect(sub.matcher.filters).to eq({"value"=>"bus_special_value_present"})
 
       QueueBus::Driver.perform(attributes.merge("bus_event_type" => "something2", "value"=>"nice"))
 
       hash = JSON.parse(QueueBus.redis { |redis| redis.lpop("queue:test2_default") })
-      hash["class"].should == "QueueBus::Worker"
-      hash["args"].size.should == 1
-      JSON.parse(hash["args"].first).should eq({"bus_class_proxy" => "SubscriberTest2", "bus_rider_app_key"=>"test2", "bus_rider_sub_key"=>"SubscriberTest2.test2", "bus_rider_queue" => "test2_default", "bus_rider_class_name"=>"SubscriberTest2",
+      expect(hash["class"]).to eq("QueueBus::Worker")
+      expect(hash["args"].size).to eq(1)
+      expect(JSON.parse(hash["args"].first)).to eq({"bus_class_proxy" => "SubscriberTest2", "bus_rider_app_key"=>"test2", "bus_rider_sub_key"=>"SubscriberTest2.test2", "bus_rider_queue" => "test2_default", "bus_rider_class_name"=>"SubscriberTest2",
                                "bus_event_type" => "something2", "value"=>"nice", "x"=>"y"}.merge(bus_attrs))
 
-      QueueBus::Runner1.value.should == 0
-      QueueBus::Runner2.value.should == 0
+      expect(QueueBus::Runner1.value).to eq(0)
+      expect(QueueBus::Runner2.value).to eq(0)
       QueueBus::Util.constantize(hash["class"]).perform(*hash["args"])
-      QueueBus::Runner1.value.should == 1
-      QueueBus::Runner2.value.should == 0
+      expect(QueueBus::Runner1.value).to eq(1)
+      expect(QueueBus::Runner2.value).to eq(0)
 
-      QueueBus::Runner1.attributes.should == {"transformed" => 4}
+      expect(QueueBus::Runner1.attributes).to eq({"transformed" => 4})
 
 
       QueueBus::Driver.perform(attributes.merge("bus_event_type" => "something2", "value"=>"12"))
 
       hash = JSON.parse(QueueBus.redis { |redis| redis.lpop("queue:test2_default") })
-      hash["class"].should == "QueueBus::Worker"
-      hash["args"].size.should == 1
-      JSON.parse(hash["args"].first).should == {"bus_class_proxy" => "SubscriberTest2", "bus_rider_app_key"=>"test2", "bus_rider_sub_key"=>"SubscriberTest2.test2", "bus_rider_queue" => "test2_default", "bus_rider_class_name"=>"SubscriberTest2",
-                               "bus_event_type" => "something2", "value"=>"12", "x"=>"y"}.merge(bus_attrs)
+      expect(hash["class"]).to eq("QueueBus::Worker")
+      expect(hash["args"].size).to eq(1)
+      expect(JSON.parse(hash["args"].first)).to eq({"bus_class_proxy" => "SubscriberTest2", "bus_rider_app_key"=>"test2", "bus_rider_sub_key"=>"SubscriberTest2.test2", "bus_rider_queue" => "test2_default", "bus_rider_class_name"=>"SubscriberTest2",
+                               "bus_event_type" => "something2", "value"=>"12", "x"=>"y"}.merge(bus_attrs))
 
-      QueueBus::Runner1.value.should == 1
-      QueueBus::Runner2.value.should == 0
+      expect(QueueBus::Runner1.value).to eq(1)
+      expect(QueueBus::Runner2.value).to eq(0)
       QueueBus::Util.constantize(hash["class"]).perform(*hash["args"])
-      QueueBus::Runner1.value.should == 2
-      QueueBus::Runner2.value.should == 0
+      expect(QueueBus::Runner1.value).to eq(2)
+      expect(QueueBus::Runner2.value).to eq(0)
 
-      QueueBus::Runner1.attributes.should == {"transformed" => 2}
+      expect(QueueBus::Runner1.attributes).to eq({"transformed" => 2})
     end
 
 
     it "should put in a different queue" do
       dispatcher = QueueBus.dispatcher_by_key("sub_module")
       all = dispatcher.subscriptions.all
-      all.size.should == 4
+      expect(all.size).to eq(4)
 
       sub = all.select{ |s| s.key == "SubModule::SubscriberTest3.test3"}.first
-      sub.queue_name.should == "sub_queue1"
-      sub.class_name.should == "SubModule::SubscriberTest3"
-      sub.key.should == "SubModule::SubscriberTest3.test3"
-      sub.matcher.filters.should == {"bus_event_type"=>"the_event"}
+      expect(sub.queue_name).to eq("sub_queue1")
+      expect(sub.class_name).to eq("SubModule::SubscriberTest3")
+      expect(sub.key).to eq("SubModule::SubscriberTest3.test3")
+      expect(sub.matcher.filters).to eq({"bus_event_type"=>"the_event"})
 
       sub = all.select{ |s| s.key == "SubModule::SubscriberTest3.the_event"}.first
-      sub.queue_name.should == "sub_queue2"
-      sub.class_name.should == "SubModule::SubscriberTest3"
-      sub.key.should == "SubModule::SubscriberTest3.the_event"
-      sub.matcher.filters.should == {"bus_event_type"=>"the_event"}
+      expect(sub.queue_name).to eq("sub_queue2")
+      expect(sub.class_name).to eq("SubModule::SubscriberTest3")
+      expect(sub.key).to eq("SubModule::SubscriberTest3.the_event")
+      expect(sub.matcher.filters).to eq({"bus_event_type"=>"the_event"})
 
       sub = all.select{ |s| s.key == "SubModule::SubscriberTest3.other"}.first
-      sub.queue_name.should == "sub_module_default"
-      sub.class_name.should == "SubModule::SubscriberTest3"
-      sub.key.should == "SubModule::SubscriberTest3.other"
-      sub.matcher.filters.should == {"bus_event_type"=>"other_event"}
+      expect(sub.queue_name).to eq("sub_module_default")
+      expect(sub.class_name).to eq("SubModule::SubscriberTest3")
+      expect(sub.key).to eq("SubModule::SubscriberTest3.other")
+      expect(sub.matcher.filters).to eq({"bus_event_type"=>"other_event"})
 
       sub = all.select{ |s| s.key == "SubModule::SubscriberTest4.test4"}.first
-      sub.queue_name.should == "sub_queue1"
-      sub.class_name.should == "SubModule::SubscriberTest4"
-      sub.key.should == "SubModule::SubscriberTest4.test4"
-      sub.matcher.filters.should == {"bus_event_type"=>"test4"}
+      expect(sub.queue_name).to eq("sub_queue1")
+      expect(sub.class_name).to eq("SubModule::SubscriberTest4")
+      expect(sub.key).to eq("SubModule::SubscriberTest4.test4")
+      expect(sub.matcher.filters).to eq({"bus_event_type"=>"test4"})
 
       QueueBus::Driver.perform(attributes.merge("bus_event_type" => "the_event"))
 
       hash = JSON.parse(QueueBus.redis { |redis| redis.lpop("queue:sub_queue1") })
-      hash["class"].should == "QueueBus::Worker"
-      hash["args"].size.should == 1
-      JSON.parse(hash["args"].first).should == {"bus_class_proxy" => "SubModule::SubscriberTest3", "bus_rider_app_key"=>"sub_module", "bus_rider_sub_key"=>"SubModule::SubscriberTest3.test3", "bus_rider_queue" => "sub_queue1", "bus_rider_class_name"=>"SubModule::SubscriberTest3",
-                                "bus_event_type" => "the_event", "x" => "y"}.merge(bus_attrs)
+      expect(hash["class"]).to eq("QueueBus::Worker")
+      expect(hash["args"].size).to eq(1)
+      expect(JSON.parse(hash["args"].first)).to eq({"bus_class_proxy" => "SubModule::SubscriberTest3", "bus_rider_app_key"=>"sub_module", "bus_rider_sub_key"=>"SubModule::SubscriberTest3.test3", "bus_rider_queue" => "sub_queue1", "bus_rider_class_name"=>"SubModule::SubscriberTest3",
+                                "bus_event_type" => "the_event", "x" => "y"}.merge(bus_attrs))
 
-      QueueBus::Runner1.value.should == 0
-      QueueBus::Runner2.value.should == 0
+      expect(QueueBus::Runner1.value).to eq(0)
+      expect(QueueBus::Runner2.value).to eq(0)
       QueueBus::Util.constantize(hash["class"]).perform(*hash["args"])
-      QueueBus::Runner1.value.should == 1
-      QueueBus::Runner2.value.should == 0
+      expect(QueueBus::Runner1.value).to eq(1)
+      expect(QueueBus::Runner2.value).to eq(0)
 
       hash = JSON.parse(QueueBus.redis { |redis| redis.lpop("queue:sub_queue2") })
-      hash["class"].should == "QueueBus::Worker"
-      hash["args"].size.should == 1
-      JSON.parse(hash["args"].first).should == {"bus_class_proxy" => "SubModule::SubscriberTest3", "bus_rider_app_key"=>"sub_module", "bus_rider_sub_key"=>"SubModule::SubscriberTest3.the_event", "bus_rider_queue" => "sub_queue2", "bus_rider_class_name"=>"SubModule::SubscriberTest3",
-                                "bus_event_type" => "the_event", "x" => "y"}.merge(bus_attrs)
+      expect(hash["class"]).to eq("QueueBus::Worker")
+      expect(hash["args"].size).to eq(1)
+      expect(JSON.parse(hash["args"].first)).to eq({"bus_class_proxy" => "SubModule::SubscriberTest3", "bus_rider_app_key"=>"sub_module", "bus_rider_sub_key"=>"SubModule::SubscriberTest3.the_event", "bus_rider_queue" => "sub_queue2", "bus_rider_class_name"=>"SubModule::SubscriberTest3",
+                                "bus_event_type" => "the_event", "x" => "y"}.merge(bus_attrs))
 
-      QueueBus::Runner1.value.should == 1
-      QueueBus::Runner2.value.should == 0
+      expect(QueueBus::Runner1.value).to eq(1)
+      expect(QueueBus::Runner2.value).to eq(0)
       QueueBus::Util.constantize(hash["class"]).perform(*hash["args"])
-      QueueBus::Runner1.value.should == 1
-      QueueBus::Runner2.value.should == 1
+      expect(QueueBus::Runner1.value).to eq(1)
+      expect(QueueBus::Runner2.value).to eq(1)
     end
 
     it "should subscribe to default and attributes" do
@@ -182,19 +182,19 @@ require 'spec_helper'
       all = dispatcher.subscriptions.all
 
       sub = all.select{ |s| s.key == "SubscriberTest1.event_sub"}.first
-      sub.queue_name.should == "myqueue"
-      sub.class_name.should == "SubscriberTest1"
-      sub.key.should == "SubscriberTest1.event_sub"
-      sub.matcher.filters.should == {"bus_event_type"=>"event_sub"}
+      expect(sub.queue_name).to eq("myqueue")
+      expect(sub.class_name).to eq("SubscriberTest1")
+      expect(sub.key).to eq("SubscriberTest1.event_sub")
+      expect(sub.matcher.filters).to eq({"bus_event_type"=>"event_sub"})
 
       sub = all.select{ |s| s.key == "SubscriberTest1.thing_filter"}.first
-      sub.queue_name.should == "myqueue"
-      sub.class_name.should == "SubscriberTest1"
-      sub.key.should == "SubscriberTest1.thing_filter"
-      sub.matcher.filters.should == {"x"=>"y"}
+      expect(sub.queue_name).to eq("myqueue")
+      expect(sub.class_name).to eq("SubscriberTest1")
+      expect(sub.key).to eq("SubscriberTest1.thing_filter")
+      expect(sub.matcher.filters).to eq({"x"=>"y"})
 
       QueueBus::Driver.perform(attributes.merge("bus_event_type" => "event_sub"))
-      QueueBus.redis { |redis| redis.smembers("queues") }.should =~ ["myqueue"]
+      expect(QueueBus.redis { |redis| redis.smembers("queues") }).to match_array(["myqueue"])
 
       pop1 = JSON.parse(QueueBus.redis { |redis| redis.lpop("queue:myqueue") })
       pop2 = JSON.parse(QueueBus.redis { |redis| redis.lpop("queue:myqueue") })
@@ -207,63 +207,63 @@ require 'spec_helper'
         hash2 = pop1
       end
 
-      hash1["class"].should == "QueueBus::Worker"
-      JSON.parse(hash1["args"].first).should eq({"bus_class_proxy" => "SubscriberTest1", "bus_rider_app_key"=>"my_thing", "bus_rider_sub_key"=>"SubscriberTest1.thing_filter", "bus_rider_queue" => "myqueue", "bus_rider_class_name"=>"SubscriberTest1",
+      expect(hash1["class"]).to eq("QueueBus::Worker")
+      expect(JSON.parse(hash1["args"].first)).to eq({"bus_class_proxy" => "SubscriberTest1", "bus_rider_app_key"=>"my_thing", "bus_rider_sub_key"=>"SubscriberTest1.thing_filter", "bus_rider_queue" => "myqueue", "bus_rider_class_name"=>"SubscriberTest1",
                                 "bus_event_type" => "event_sub", "x" => "y"}.merge(bus_attrs))
 
-      QueueBus::Runner1.value.should == 0
-      QueueBus::Runner2.value.should == 0
+      expect(QueueBus::Runner1.value).to eq(0)
+      expect(QueueBus::Runner2.value).to eq(0)
       QueueBus::Util.constantize(hash1["class"]).perform(*hash1["args"])
-      QueueBus::Runner1.value.should == 0
-      QueueBus::Runner2.value.should == 1
+      expect(QueueBus::Runner1.value).to eq(0)
+      expect(QueueBus::Runner2.value).to eq(1)
 
-      hash2["class"].should == "QueueBus::Worker"
-      hash2["args"].size.should == 1
-      JSON.parse(hash2["args"].first).should == {"bus_class_proxy" => "SubscriberTest1", "bus_rider_app_key"=>"my_thing", "bus_rider_sub_key"=>"SubscriberTest1.event_sub", "bus_rider_queue" => "myqueue", "bus_rider_class_name"=>"SubscriberTest1",
-                                "bus_event_type" => "event_sub", "x" => "y"}.merge(bus_attrs)
+      expect(hash2["class"]).to eq("QueueBus::Worker")
+      expect(hash2["args"].size).to eq(1)
+      expect(JSON.parse(hash2["args"].first)).to eq({"bus_class_proxy" => "SubscriberTest1", "bus_rider_app_key"=>"my_thing", "bus_rider_sub_key"=>"SubscriberTest1.event_sub", "bus_rider_queue" => "myqueue", "bus_rider_class_name"=>"SubscriberTest1",
+                                "bus_event_type" => "event_sub", "x" => "y"}.merge(bus_attrs))
 
-      QueueBus::Runner1.value.should == 0
-      QueueBus::Runner2.value.should == 1
+      expect(QueueBus::Runner1.value).to eq(0)
+      expect(QueueBus::Runner2.value).to eq(1)
       QueueBus::Util.constantize(hash2["class"]).perform(*hash2["args"])
-      QueueBus::Runner1.value.should == 1
-      QueueBus::Runner2.value.should == 1
+      expect(QueueBus::Runner1.value).to eq(1)
+      expect(QueueBus::Runner2.value).to eq(1)
 
       QueueBus::Driver.perform(attributes.merge("bus_event_type" => "event_sub_other"))
-      QueueBus.redis { |redis| redis.smembers("queues") }.should =~ ["myqueue"]
+      expect(QueueBus.redis { |redis| redis.smembers("queues") }).to match_array(["myqueue"])
 
       hash = JSON.parse(QueueBus.redis { |redis| redis.lpop("queue:myqueue") })
-      hash["class"].should == "QueueBus::Worker"
-      hash["args"].size.should == 1
-      JSON.parse(hash["args"].first).should == {"bus_class_proxy" => "SubscriberTest1", "bus_rider_app_key"=>"my_thing", "bus_rider_sub_key"=>"SubscriberTest1.thing_filter", "bus_rider_queue" => "myqueue", "bus_rider_class_name"=>"SubscriberTest1",
-                                "bus_event_type" => "event_sub_other", "x" => "y"}.merge(bus_attrs)
+      expect(hash["class"]).to eq("QueueBus::Worker")
+      expect(hash["args"].size).to eq(1)
+      expect(JSON.parse(hash["args"].first)).to eq({"bus_class_proxy" => "SubscriberTest1", "bus_rider_app_key"=>"my_thing", "bus_rider_sub_key"=>"SubscriberTest1.thing_filter", "bus_rider_queue" => "myqueue", "bus_rider_class_name"=>"SubscriberTest1",
+                                "bus_event_type" => "event_sub_other", "x" => "y"}.merge(bus_attrs))
 
-      QueueBus::Runner1.value.should == 1
-      QueueBus::Runner2.value.should == 1
+      expect(QueueBus::Runner1.value).to eq(1)
+      expect(QueueBus::Runner2.value).to eq(1)
       QueueBus::Util.constantize(hash["class"]).perform(*hash["args"])
-      QueueBus::Runner1.value.should == 1
-      QueueBus::Runner2.value.should == 2
+      expect(QueueBus::Runner1.value).to eq(1)
+      expect(QueueBus::Runner2.value).to eq(2)
 
       QueueBus::Driver.perform({"x"=>"z"}.merge("bus_event_type" => "event_sub_other"))
-      QueueBus.redis { |redis| redis.smembers("queues") }.should =~ ["myqueue"]
+      expect(QueueBus.redis { |redis| redis.smembers("queues") }).to match_array(["myqueue"])
 
-      QueueBus.redis { |redis| redis.lpop("queue:myqueue") }.should be_nil
+      expect(QueueBus.redis { |redis| redis.lpop("queue:myqueue") }).to be_nil
     end
 
     describe ".perform" do
       let(:attributes) { {"bus_rider_sub_key"=>"SubscriberTest1.event_sub", "bus_locale" => "en", "bus_timezone" => "PST"} }
       it "should call the method based on key" do
-        SubscriberTest1.any_instance.should_receive(:event_sub)
+        expect_any_instance_of(SubscriberTest1).to receive(:event_sub)
         SubscriberTest1.perform(attributes)
       end
       it "should set the timezone and locale if present" do
-        defined?(I18n).should be_nil
-        Time.respond_to?(:zone).should eq(false)
+        expect(defined?(I18n)).to be_nil
+        expect(Time.respond_to?(:zone)).to eq(false)
 
         stub_const("I18n", Class.new)
-        I18n.should_receive(:locale=).with("en")
-        Time.should_receive(:zone=).with("PST")
+        expect(I18n).to receive(:locale=).with("en")
+        expect(Time).to receive(:zone=).with("PST")
 
-        SubscriberTest1.any_instance.should_receive(:event_sub)
+        expect_any_instance_of(SubscriberTest1).to receive(:event_sub)
         SubscriberTest1.perform(attributes)
       end
     end

--- a/spec/subscription_list_spec.rb
+++ b/spec/subscription_list_spec.rb
@@ -10,28 +10,28 @@ module QueueBus
 
       it "should return from attributes" do
         list = SubscriptionList.from_redis(mult)
-        list.size.should == 2
+        expect(list.size).to eq(2)
         one = list.key("event_one")
         two = list.key("event_two")
         
-        one.key.should == "event_one"
-        one.key.should == "event_one"
-        one.queue_name.should == "default"
-        one.class_name.should == "MyClass"
-        one.matcher.filters.should == {"bus_event_type" => "event_one"}
+        expect(one.key).to eq("event_one")
+        expect(one.key).to eq("event_one")
+        expect(one.queue_name).to eq("default")
+        expect(one.class_name).to eq("MyClass")
+        expect(one.matcher.filters).to eq({"bus_event_type" => "event_one"})
         
-        two.key.should == "event_two"
-        two.key.should == "event_two"
-        two.queue_name.should == "else"
-        two.class_name.should == "MyClass"
-        two.matcher.filters.should == {"bus_event_type" => "event_two"}
+        expect(two.key).to eq("event_two")
+        expect(two.key).to eq("event_two")
+        expect(two.queue_name).to eq("else")
+        expect(two.class_name).to eq("MyClass")
+        expect(two.matcher.filters).to eq({"bus_event_type" => "event_two"})
       end
 
       it "raises an error if a subscription key already exists" do
         mult["event_two"]["key"] = "event_one"
 
-        lambda { SubscriptionList.from_redis(mult) }
-          .should raise_error(RuntimeError)
+        expect { SubscriptionList.from_redis(mult) }
+          .to raise_error(RuntimeError)
       end
     end
     
@@ -42,9 +42,9 @@ module QueueBus
         list.add(Subscription.new("else_ok", "key2", "MyClass", {"bus_event_type" => "event_two"}))
         
         hash = list.to_redis
-        hash.should == {  "key1" => {"queue_name" => "default", "key" => "key1", "class" => "MyClass", "matcher" => {"bus_event_type" => "event_one"}}, 
+        expect(hash).to eq({  "key1" => {"queue_name" => "default", "key" => "key1", "class" => "MyClass", "matcher" => {"bus_event_type" => "event_one"}}, 
                           "key2" => {"queue_name" => "else_ok", "key" => "key2", "class" => "MyClass", "matcher" => {"bus_event_type" => "event_two"}}
-                       }
+                       })
         
       end
     end

--- a/spec/subscription_spec.rb
+++ b/spec/subscription_spec.rb
@@ -3,27 +3,27 @@ require 'spec_helper'
 module QueueBus
   describe Subscription do
     it "should normalize the queue name" do
-      Subscription.new("test",  "my_event", "MyClass", {}, nil).queue_name.should == "test"
-      Subscription.new("tes t", "my_event", "MyClass", {}, nil).queue_name.should == "tes_t"
-      Subscription.new("t%s",   "my_event", "MyClass", {}, nil).queue_name.should == "t_s"
+      expect(Subscription.new("test",  "my_event", "MyClass", {}, nil).queue_name).to eq("test")
+      expect(Subscription.new("tes t", "my_event", "MyClass", {}, nil).queue_name).to eq("tes_t")
+      expect(Subscription.new("t%s",   "my_event", "MyClass", {}, nil).queue_name).to eq("t_s")
     end
     
     describe ".register" do
       it "should take in args from dispatcher" do
         executor = Proc.new { |attributes| }
         sub = Subscription.register("queue_name", "mykey", "MyClass", {"bus_event_type" => "my_event"}, executor)
-        sub.send(:executor).should == executor
-        sub.matcher.filters.should == {"bus_event_type" => "my_event"}
-        sub.queue_name.should == "queue_name"
-        sub.key.should == "mykey"
-        sub.class_name.should == "MyClass"
+        expect(sub.send(:executor)).to eq(executor)
+        expect(sub.matcher.filters).to eq({"bus_event_type" => "my_event"})
+        expect(sub.queue_name).to eq("queue_name")
+        expect(sub.key).to eq("mykey")
+        expect(sub.class_name).to eq("MyClass")
       end
     end
     
     describe "#execute!" do
       it "should call the executor with the attributes" do
         exec = Object.new
-        exec.should_receive(:call)
+        expect(exec).to receive(:call)
         
         sub = Subscription.new("x", "y", "ClassName", {}, exec)
         sub.execute!({"ok" => true})
@@ -33,19 +33,19 @@ module QueueBus
     describe "#to_redis" do
       it "should return what to store for this subscription" do
         sub = Subscription.new("queue_one", "xyz", "ClassName", {"bus_event_type" => "my_event"}, nil)
-        sub.to_redis.should == {"queue_name" => "queue_one", "key" => "xyz", "class" => "ClassName", "matcher" => {"bus_event_type" => "my_event"}}
+        expect(sub.to_redis).to eq({"queue_name" => "queue_one", "key" => "xyz", "class" => "ClassName", "matcher" => {"bus_event_type" => "my_event"}})
       end
     end
     
     describe "#matches?" do
       it "should do pattern stuff" do
-        Subscription.new("x", "id", "ClassName", {"bus_event_type" => "one"}).matches?("bus_event_type" => "one").should == true
-        Subscription.new("x", "id", "ClassName", {"bus_event_type" => "one"}).matches?("bus_event_type" => "onex").should == false
-        Subscription.new("x", "id", "ClassName", {"bus_event_type" => "^one.*$"}).matches?("bus_event_type" => "onex").should == true
-        Subscription.new("x", "id", "ClassName", {"bus_event_type" => "one.*"}).matches?("bus_event_type" => "onex").should == true
-        Subscription.new("x", "id", "ClassName", {"bus_event_type" => "one.?"}).matches?("bus_event_type" => "onex").should == true
-        Subscription.new("x", "id", "ClassName", {"bus_event_type" => "one.?"}).matches?("bus_event_type" => "one").should == true
-        Subscription.new("x", "id", "ClassName", {"bus_event_type" => "\\"}).matches?("bus_event_type" => "one").should == false
+        expect(Subscription.new("x", "id", "ClassName", {"bus_event_type" => "one"}).matches?("bus_event_type" => "one")).to eq(true)
+        expect(Subscription.new("x", "id", "ClassName", {"bus_event_type" => "one"}).matches?("bus_event_type" => "onex")).to eq(false)
+        expect(Subscription.new("x", "id", "ClassName", {"bus_event_type" => "^one.*$"}).matches?("bus_event_type" => "onex")).to eq(true)
+        expect(Subscription.new("x", "id", "ClassName", {"bus_event_type" => "one.*"}).matches?("bus_event_type" => "onex")).to eq(true)
+        expect(Subscription.new("x", "id", "ClassName", {"bus_event_type" => "one.?"}).matches?("bus_event_type" => "onex")).to eq(true)
+        expect(Subscription.new("x", "id", "ClassName", {"bus_event_type" => "one.?"}).matches?("bus_event_type" => "one")).to eq(true)
+        expect(Subscription.new("x", "id", "ClassName", {"bus_event_type" => "\\"}).matches?("bus_event_type" => "one")).to eq(false)
       end
     end
     

--- a/spec/worker_spec.rb
+++ b/spec/worker_spec.rb
@@ -4,29 +4,29 @@ module QueueBus
   describe Worker do
     it "should proxy to given class" do
       hash = {"bus_class_proxy" => "QueueBus::Driver", "ok" => true}
-      QueueBus::Driver.should_receive(:perform).with(hash)
+      expect(QueueBus::Driver).to receive(:perform).with(hash)
       QueueBus::Worker.perform(JSON.generate(hash))
     end
 
     it "should use instance" do
       hash = {"bus_class_proxy" => "QueueBus::Rider", "ok" => true}
-      QueueBus::Rider.should_receive(:perform).with(hash)
+      expect(QueueBus::Rider).to receive(:perform).with(hash)
       QueueBus::Worker.new.perform(JSON.generate(hash))
     end
 
     it "should not freak out if class not there anymore" do
       hash = {"bus_class_proxy" => "QueueBus::BadClass", "ok" => true}
-      lambda {
+      expect {
         QueueBus::Worker.perform(JSON.generate(hash))
-      }.should_not raise_error
+      }.not_to raise_error
     end
 
     it "should raise error if proxy raises error" do
       hash = {"bus_class_proxy" => "QueueBus::Rider", "ok" => true}
-      QueueBus::Rider.should_receive(:perform).with(hash).and_raise("rider crash")
-      lambda {
+      expect(QueueBus::Rider).to receive(:perform).with(hash).and_raise("rider crash")
+      expect {
         QueueBus::Worker.perform(JSON.generate(hash))
-      }.should raise_error
+      }.to raise_error
     end
   end
 end


### PR DESCRIPTION
RSpec has deprecated and moved away from the monkey patching style of
expectations using "should." To comply with that, this commit converts
all of the old "should" syntax to "expect" syntax.