### PR TITLE
Creates worker middleware

### DIFF
--- a/lib/queue-bus.rb
+++ b/lib/queue-bus.rb
@@ -40,7 +40,7 @@ module QueueBus
                             :hostname=, :hostname,
                             :adapter=, :adapter,
                             :incoming_queue=, :incoming_queue,
-                            :redis
+                            :redis, :worker_middleware_stack
 
     def_delegators :_dispatchers, :dispatch, :dispatchers, :dispatcher_by_key, :dispatcher_execute
 

--- a/lib/queue-bus.rb
+++ b/lib/queue-bus.rb
@@ -11,6 +11,7 @@ module QueueBus
   autoload :Heartbeat,        'queue_bus/heartbeat'
   autoload :Local,            'queue_bus/local'
   autoload :Matcher,          'queue_bus/matcher'
+  autoload :Middleware,       'queue_bus/middleware'
   autoload :Publishing,       'queue_bus/publishing'
   autoload :Publisher,        'queue_bus/publisher'
   autoload :Rider,            'queue_bus/rider'

--- a/lib/queue_bus/config.rb
+++ b/lib/queue_bus/config.rb
@@ -55,6 +55,10 @@ module QueueBus
       @incoming_queue ||= "bus_incoming"
     end
 
+    def worker_middleware_stack
+      @worker_middleware_stack ||= QueueBus::Middleware::Stack.new
+    end
+
     def hostname
       @hostname ||= `hostname 2>&1`.strip.sub(/.local/,'')
     end

--- a/lib/queue_bus/middleware.rb
+++ b/lib/queue_bus/middleware.rb
@@ -1,0 +1,54 @@
+# frozen_string_literal: true
+
+module QueueBus
+  module Middleware
+    # A base class for implementing a middleware. Inheriting from this will
+    # provide a constructor and a basic call method. Override the call method
+    # to implement your own logic. Calling the instance variable `@app` will
+    # drive the middleware stack.
+    class Abstract
+      def initialize(app)
+        @app = app
+      end
+
+      def call(_args)
+        @app.call
+      end
+    end
+
+    # A stack of middleware. You can modify the stack using the provided
+    # helper methods.
+    class Stack
+      def initialize
+        @middlewares = []
+      end
+
+      def use(middleware)
+        @middlewares << middleware
+      end
+
+      def run(args, &inner)
+        Runner.new(args: args, stack: @middlewares.dup, inner: inner).call
+      end
+    end
+
+    # Runs the middleware stack by passing it self to each class.
+    class Runner
+      def initialize(args:, stack:, inner:)
+        @stack = stack
+        @inner = inner
+        @args = args
+      end
+
+      def call
+        middleware = @stack.shift
+
+        if middleware
+          middleware.new(self).call(@args)
+        else
+          @inner.call
+        end
+      end
+    end
+  end
+end

--- a/lib/queue_bus/worker.rb
+++ b/lib/queue_bus/worker.rb
@@ -12,7 +12,9 @@ module QueueBus
         return
       end
 
-      klass.perform(attributes)
+      QueueBus.worker_middleware_stack.run(attributes) do
+        klass.perform(attributes)
+      end
     end
 
     # all our workers include this one

--- a/spec/middleware_spec.rb
+++ b/spec/middleware_spec.rb
@@ -1,0 +1,112 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+RSpec.describe QueueBus::Middleware do
+  subject { described_class::Stack.new }
+
+  let(:args) { { rand: rand } }
+  let(:inner) { proc {} }
+
+  let(:base_class) do
+    # Creates a unique base class that provides tracking of calls.
+    Class.new(QueueBus::Middleware::Abstract) do
+      class << self
+        attr_accessor :called_at
+      end
+
+      def call(_args)
+        self.class.called_at = Time.now
+        @app.call
+      end
+    end
+  end
+
+  context 'with none configured' do
+    it 'falls through' do
+      expect(inner).to receive(:call)
+      subject.run(args, &inner)
+    end
+  end
+
+  context 'with the abstract class configured' do
+    before do
+      subject.use(QueueBus::Middleware::Abstract)
+    end
+
+    it 'runs the inner' do
+      expect(inner).to receive(:call).and_call_original
+      subject.run(args, &inner)
+    end
+  end
+
+  context 'with one middleware' do
+    let(:middleware) do
+      Class.new(base_class) do
+        class << self
+          attr_accessor :args
+        end
+
+        def call(args)
+          self.class.args = args
+          super
+        end
+      end
+    end
+
+    before do
+      subject.use(middleware)
+    end
+
+    it 'calls the middleware with the args' do
+      subject.run(args, &inner)
+
+      expect(middleware.args).to eql args
+    end
+
+    it 'calls the middleware and then inner' do
+      expect(inner).to receive(:call).and_call_original
+      subject.run(args, &inner)
+      expect(middleware.called_at).not_to be_nil
+    end
+
+    context 'and the middleware does not yield' do
+      let(:middleware) do
+        Class.new(base_class) do
+          def call(_args)
+            self.class.called_at = Time.now
+            # no-op
+          end
+        end
+      end
+
+      it 'does not run inner' do
+        expect(inner).not_to receive(:call).and_call_original
+        subject.run(args, &inner)
+        expect(middleware.called_at).not_to be_nil
+      end
+    end
+  end
+
+  context 'with more than one middleware' do
+    let(:middlewares) do
+      Array.new(rand(2..20)).map do
+        Class.new(base_class)
+      end
+    end
+
+    before do
+      middlewares.each do |middleware|
+        subject.use(middleware)
+      end
+    end
+
+    it 'calls all the middlewares in order' do
+      expect(inner).to receive(:call).and_call_original
+      subject.run(args, &inner)
+      # Test by sorting by when it was called. This should be in a strict
+      # order based on call order.
+      expect(middlewares.sort_by(&:called_at)).to eq middlewares
+    end
+  end
+end

--- a/spec/worker_spec.rb
+++ b/spec/worker_spec.rb
@@ -1,32 +1,37 @@
 require 'spec_helper'
+require 'json'
 
-module QueueBus
-  describe Worker do
-    it "should proxy to given class" do
-      hash = {"bus_class_proxy" => "QueueBus::Driver", "ok" => true}
-      expect(QueueBus::Driver).to receive(:perform).with(hash)
+describe QueueBus::Worker do
+  it "proxies to given class" do
+    hash = {"bus_class_proxy" => "QueueBus::Driver", "ok" => true}
+    expect(QueueBus::Driver).to receive(:perform).with(hash)
+    QueueBus::Worker.perform(JSON.generate(hash))
+  end
+
+  it "uses an instance" do
+    hash = {"bus_class_proxy" => "QueueBus::Rider", "ok" => true}
+    expect(QueueBus::Rider).to receive(:perform).with(hash)
+    QueueBus::Worker.new.perform(JSON.generate(hash))
+  end
+
+  it "does not freak out if class not there anymore" do
+    hash = {"bus_class_proxy" => "QueueBus::BadClass", "ok" => true}
+    expect {
       QueueBus::Worker.perform(JSON.generate(hash))
-    end
+    }.not_to raise_error
+  end
 
-    it "should use instance" do
-      hash = {"bus_class_proxy" => "QueueBus::Rider", "ok" => true}
-      expect(QueueBus::Rider).to receive(:perform).with(hash)
-      QueueBus::Worker.new.perform(JSON.generate(hash))
-    end
+  it "raises error if proxy raises error" do
+    hash = {"bus_class_proxy" => "QueueBus::Rider", "ok" => true}
+    expect(QueueBus::Rider).to receive(:perform).with(hash).and_raise("rider crash")
+    expect {
+      QueueBus::Worker.perform(JSON.generate(hash))
+    }.to raise_error(RuntimeError, 'rider crash')
+  end
 
-    it "should not freak out if class not there anymore" do
-      hash = {"bus_class_proxy" => "QueueBus::BadClass", "ok" => true}
-      expect {
-        QueueBus::Worker.perform(JSON.generate(hash))
-      }.not_to raise_error
-    end
-
-    it "should raise error if proxy raises error" do
-      hash = {"bus_class_proxy" => "QueueBus::Rider", "ok" => true}
-      expect(QueueBus::Rider).to receive(:perform).with(hash).and_raise("rider crash")
-      expect {
-        QueueBus::Worker.perform(JSON.generate(hash))
-      }.to raise_error(RuntimeError, 'rider crash')
-    end
+  it "runs the middleware stack" do
+    hash = {"bus_class_proxy" => "QueueBus::Driver", "ok" => true}
+    expect(QueueBus.worker_middleware_stack).to receive(:run).with(hash).and_yield
+    QueueBus::Worker.perform(JSON.generate(hash))
   end
 end


### PR DESCRIPTION
To provide an agnostic way of wrapping and controlling the worker, a
middleware stack is built that can have middlewares added to it and then
reliably call down the stack.

In order to use the middleware, we need to have it wrap a call. This
commit wraps the klass.perform callout from the worker and passes the
attributes as the args to the middleware.