### PR TITLE
Resolves rspec warnings about raise_error

### DIFF
--- a/spec/application_spec.rb
+++ b/spec/application_spec.rb
@@ -31,15 +31,15 @@ module QueueBus
       it "should raise an error if not valid" do
         expect {
           Application.new("")
-        }.to raise_error
+        }.to raise_error(RuntimeError, "Invalid application name")
 
         expect {
           Application.new(nil)
-        }.to raise_error
+        }.to raise_error(RuntimeError, "Invalid application name")
 
         expect {
           Application.new("/")
-        }.to raise_error
+        }.to raise_error(RuntimeError, "Invalid application name")
       end
     end
 

--- a/spec/config_spec.rb
+++ b/spec/config_spec.rb
@@ -54,7 +54,7 @@ describe "QueueBus config" do
     # and should raise if already set
     expect {
       QueueBus.adapter = :data
-    }.to raise_error
+    }.to raise_error(RuntimeError, "Adapter already set to QueueBus::Adapters::Data")
   end
 
   context "with a fresh load" do
@@ -69,7 +69,7 @@ describe "QueueBus config" do
       # and should raise if already set
       expect {
         QueueBus.adapter = :data
-      }.to raise_error
+      }.to raise_error(RuntimeError, "Adapter already set to QueueBus::Adapters::Data")
     end
 
     it "should be able to be set to something else" do

--- a/spec/worker_spec.rb
+++ b/spec/worker_spec.rb
@@ -26,7 +26,7 @@ module QueueBus
       expect(QueueBus::Rider).to receive(:perform).with(hash).and_raise("rider crash")
       expect {
         QueueBus::Worker.perform(JSON.generate(hash))
-      }.to raise_error
+      }.to raise_error(RuntimeError, 'rider crash')
     end
   end
 end


### PR DESCRIPTION
The matcher `raise_error` issues a warning if it's used in an affirmative
context without an explict error type. To resolve these warnings (which
warn of false positives) the commit adds in the explicit error classes
and values.