### PR TITLE
Allow checking if adapter is set

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,0 +1,35 @@
+AllCops:
+  TargetRubyVersion: 2.4
+  ExtraDetails: true
+
+# http://rubocop.readthedocs.io/en/latest/cops_style/#stylefrozenstringliteralcomment
+Style/FrozenStringLiteralComment:
+  Enabled: true
+
+# https://rubocop.readthedocs.io/en/latest/cops_style/#styledatetime
+Style/DateTime:
+  Enabled: true
+
+# http://rubocop.readthedocs.io/en/latest/cops_metrics/#metricslinelength
+Metrics/LineLength:
+  Max: 100
+
+Metrics/MethodLength:
+  Max: 15
+
+Metrics/BlockLength:
+  Exclude:
+    - spec/**/*
+
+# https://rubocop.readthedocs.io/en/latest/cops_layout/#layoutdotposition
+Layout/DotPosition:
+  Enabled: true
+  EnforcedStyle: leading
+
+# https://rubocop.readthedocs.io/en/latest/cops_style/#stylehashsyntax
+Style/HashSyntax:
+  Enabled: true
+
+# https://rubocop-rspec.readthedocs.io/en/latest/cops_rspec/#rspecfocus
+RSpec/Focus:
+  Enabled: true

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- Adds `QueueBus.has_adapter?` to check whether the adapter is set.
+
+### Changed
+- Now uses `Process.hostname` to determine hostname versus relying on unix shell.
+- Rubocop is now a dev dependency.
+- Accessors to config are now done with actual attrs.
+- Logging with the adapter will use the logger if present.
+
+### Fixed
+- Passing a class to `adapter=` would error on a `NameError`.
+
 ## [0.6.0]
 
 ### Added

--- a/lib/queue-bus.rb
+++ b/lib/queue-bus.rb
@@ -38,7 +38,7 @@ module QueueBus
                             :before_publish=, :before_publish_callback,
                             :logger=, :logger, :log_application, :log_worker,
                             :hostname=, :hostname,
-                            :adapter=, :adapter,
+                            :adapter=, :adapter, :has_adapter?,
                             :incoming_queue=, :incoming_queue,
                             :redis, :worker_middleware_stack
 
@@ -60,5 +60,4 @@ module QueueBus
       @_dispatchers ||= ::QueueBus::Dispatchers.new
     end
   end
-
 end

--- a/lib/queue_bus/config.rb
+++ b/lib/queue_bus/config.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require 'socket'
+require 'logger'
 
 module QueueBus
   # This class contains all the configuration for a running queue bus application.
@@ -63,7 +64,7 @@ module QueueBus
     end
 
     def log_worker(message)
-      logger&.debug(message) if ENV['LOGGING'] || ENV['VERBOSE'] || ENV['VVERBOSE']
+      logger&.debug(message)
     end
   end
 end

--- a/queue-bus.gemspec
+++ b/queue-bus.gemspec
@@ -29,4 +29,5 @@ Gem::Specification.new do |s|
   s.add_development_dependency("rspec")
   s.add_development_dependency("timecop")
   s.add_development_dependency("json_pure")
+  s.add_development_dependency("rubocop")
 end

--- a/spec/config_spec.rb
+++ b/spec/config_spec.rb
@@ -1,83 +1,124 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 
-module QueueBus
-  module Adapters
-    class TestOne
-
-    end
-  end
-end
-
-describe "QueueBus config" do
-  it "should set the default app key" do
+describe 'QueueBus config' do
+  it 'sets the default app key' do
     expect(QueueBus.default_app_key).to eq(nil)
 
-    QueueBus.default_app_key = "my_app"
-    expect(QueueBus.default_app_key).to eq("my_app")
+    QueueBus.default_app_key = 'my_app'
+    expect(QueueBus.default_app_key).to eq('my_app')
 
-    QueueBus.default_app_key = "something here"
-    expect(QueueBus.default_app_key).to eq("something_here")
+    QueueBus.default_app_key = 'something here'
+    expect(QueueBus.default_app_key).to eq('something_here')
   end
 
-  it "should set the default queue" do
+  it 'sets the default queue' do
     expect(QueueBus.default_queue).to eq(nil)
 
-    QueueBus.default_queue = "my_queue"
-    expect(QueueBus.default_queue).to eq("my_queue")
+    QueueBus.default_queue = 'my_queue'
+    expect(QueueBus.default_queue).to eq('my_queue')
   end
 
-  it "should set the local mode" do
+  it 'sets the local mode' do
     expect(QueueBus.local_mode).to eq(nil)
     QueueBus.local_mode = :standalone
     expect(QueueBus.local_mode).to eq(:standalone)
   end
 
-  it "should set the hostname" do
+  it 'sets the hostname' do
     expect(QueueBus.hostname).not_to eq(nil)
-    QueueBus.hostname = "whatever"
-    expect(QueueBus.hostname).to eq("whatever")
+    QueueBus.hostname = 'whatever'
+    expect(QueueBus.hostname).to eq('whatever')
   end
 
-  it "should set before_publish callback" do
-    QueueBus.before_publish = lambda {|attributes| 42 }
+  it 'sets before_publish callback' do
+    QueueBus.before_publish = ->(_attr) { 42 }
     expect(QueueBus.before_publish_callback({})).to eq(42)
   end
 
-
-  it "should use the default Redis connection" do
+  it 'uses the default Redis connection' do
     expect(QueueBus.redis { |redis| redis }).not_to eq(nil)
   end
 
-  it "should default to given adapter" do
+  it 'defaults to given adapter' do
     expect(QueueBus.adapter.is_a?(adapter_under_test_class)).to eq(true)
 
     # and should raise if already set
-    expect {
-      QueueBus.adapter = :data
-    }.to raise_error(RuntimeError, "Adapter already set to QueueBus::Adapters::Data")
+    expect { QueueBus.adapter = :data }
+      .to raise_error(RuntimeError, 'Adapter already set to QueueBus::Adapters::Data')
   end
 
-  context "with a fresh load" do
+  context 'with a fresh load' do
     before(:each) do
       QueueBus.send(:reset)
     end
 
-    it "should be able to be set to resque" do
-      QueueBus.adapter = adapter_under_test_symbol
-      expect(QueueBus.adapter.is_a?(adapter_under_test_class)).to eq(true)
+    context 'when set to adapter under test' do
+      before do
+        QueueBus.adapter = adapter_under_test_symbol
+      end
 
-      # and should raise if already set
-      expect {
-        QueueBus.adapter = :data
-      }.to raise_error(RuntimeError, "Adapter already set to QueueBus::Adapters::Data")
+      it 'sets to that adapter' do
+        expect(QueueBus.adapter).to be_a adapter_under_test_class
+      end
     end
 
-    it "should be able to be set to something else" do
+    context 'when already set' do
+      before do
+        QueueBus.adapter = :data
+      end
 
-      QueueBus.adapter = :test_one
-      expect(QueueBus.adapter.is_a?(QueueBus::Adapters::TestOne)).to eq(true)
+      it 'raises' do
+        expect { QueueBus.adapter = :data }
+          .to raise_error(RuntimeError, 'Adapter already set to QueueBus::Adapters::Data')
+      end
+
+      it 'knows the adapter is set' do
+        expect(QueueBus).to have_adapter
+      end
+    end
+
+    context 'with a symbol' do
+      before do
+        QueueBus.adapter = :data
+      end
+
+      it 'looks up the known class' do
+        expect(QueueBus.adapter).to be_a QueueBus::Adapters::Data
+      end
+    end
+
+    context 'with a custom adapter' do
+      let(:klass) do
+        Class.new(QueueBus::Adapters::Base) do
+          def enabled!
+            # no op
+          end
+
+          def redis
+            # no op
+          end
+        end
+      end
+
+      before do
+        QueueBus.adapter = klass.new
+      end
+
+      it 'sets it to something else' do
+        expect(QueueBus.adapter).to be_a klass
+      end
+    end
+
+    context 'with a class' do
+      before do
+        QueueBus.adapter = QueueBus::Adapters::Data
+      end
+
+      it 'creates a new one' do
+        expect(QueueBus.adapter).to be_a QueueBus::Adapters::Data
+      end
     end
   end
-
-
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'timecop'
 require 'queue-bus'
 require 'adapter/support'
@@ -33,9 +35,9 @@ module QueueBus
   end
 end
 
-def test_sub(event_name, queue="default")
-  matcher = {"bus_event_type" => event_name}
-  QueueBus::Subscription.new(queue, event_name, "::QueueBus::Rider", matcher, nil)
+def test_sub(event_name, queue = 'default')
+  matcher = { 'bus_event_type' => event_name }
+  QueueBus::Subscription.new(queue, event_name, '::QueueBus::Rider', matcher, nil)
 end
 
 def test_list(*args)
@@ -50,6 +52,7 @@ RSpec.configure do |config|
   config.mock_with :rspec do |c|
     c.syntax = :expect
   end
+
   config.expect_with :rspec do |c|
     c.syntax = :expect
   end
@@ -57,10 +60,12 @@ RSpec.configure do |config|
   config.before(:each) do
     reset_test_adapter
   end
+
   config.after(:each) do
     begin
-      QueueBus.redis { |redis| redis.flushall }
-    rescue
+      QueueBus.redis(&:flushall)
+    rescue RuntimeError # rubocop:disable Lint/HandleExceptions
+      # We raise if redis isn't there.
     end
     QueueBus.send(:reset)
     QueueBus::Runner1.reset


### PR DESCRIPTION
This PR does a few things:

1. Brings in rubocop to standardize our lint rules
2. Removes the environment variable conditions for logging the worker and just logs via debug on the logger.
3. Adds a public method to check if the queue bus has an adapter set. This is the important change driving the PR. This new method will allow sidekiq-bus and resque-bus conditionally attempt to change the adapter instead of raising an exception.
4. Refactors the Config class to use `attr_` and `initialize` to configure it.
