### PR TITLE
Adds ability to temporarily modify the local mode

### DIFF
--- a/README.mdown
+++ b/README.mdown
@@ -141,11 +141,13 @@ event to the appropriate code block.
 You can also say `QueueBus.local_mode = :suppress` to turn off publishing altogether.
 This can be helpful inside some sort of migration, for example.
 
-#### Temporary Local Modes
+#### Thread Safe Local Modes
+
+**!! This is important if you are using workers that utilize multiple threads, such as Sidekiq !!**
 
 The above setting is global to the ruby process and modifying it will impact all threads that are
-currently using QueueBus. If you want to isolate a thread or block of code from QueueBus using
-local mode you can use the method `with_local_mode`:
+currently using QueueBus. If you want to isolate a thread or block of code from QueueBus, you can
+use the method `with_local_mode`:
 
 ```ruby
 QueueBus.with_local_mode(:suppress) do
@@ -153,7 +155,7 @@ QueueBus.with_local_mode(:suppress) do
 end
 ```
 
-The previous value of local_mode will be restored after the block exits.
+The previous value of `local_mode` will be restored after the block exits.
 
 ### TODO
 

--- a/README.mdown
+++ b/README.mdown
@@ -141,6 +141,20 @@ event to the appropriate code block.
 You can also say `QueueBus.local_mode = :suppress` to turn off publishing altogether.
 This can be helpful inside some sort of migration, for example.
 
+#### Temporary Local Modes
+
+The above setting is global to the ruby process and modifying it will impact all threads that are
+currently using QueueBus. If you want to isolate a thread or block of code from QueueBus using
+local mode you can use the method `with_local_mode`:
+
+```ruby
+QueueBus.with_local_mode(:suppress) do
+  # QueueBus will be suppressed on this thread, within this block.
+end
+```
+
+The previous value of local_mode will be restored after the block exits.
+
 ### TODO
 
 * Replace local modes with adapters

--- a/lib/queue-bus.rb
+++ b/lib/queue-bus.rb
@@ -34,7 +34,7 @@ module QueueBus
 
     def_delegators :config, :default_app_key=, :default_app_key,
                             :default_queue=, :default_queue,
-                            :local_mode=, :local_mode,
+                            :local_mode=, :local_mode, :with_local_mode,
                             :before_publish=, :before_publish_callback,
                             :logger=, :logger, :log_application, :log_worker,
                             :hostname=, :hostname,

--- a/lib/queue_bus/config.rb
+++ b/lib/queue_bus/config.rb
@@ -23,10 +23,12 @@ module QueueBus
     # be deleted.
     Wrap = Struct.new(:value)
 
+    LOCAL_MODE_VAR = :queue_bus_local_mode
+
     # Returns the current local mode of QueueBus
     def local_mode
-      if Thread.current.thread_variable?(:queue_bus_local_mode)
-        Thread.current.thread_variable_get(:queue_bus_local_mode).value
+      if Thread.current.thread_variable?(LOCAL_MODE_VAR)
+        Thread.current.thread_variable_get(LOCAL_MODE_VAR).value
       else
         @local_mode
       end
@@ -37,11 +39,11 @@ module QueueBus
     #
     # @param mode [Symbol] the mode to switch to
     def with_local_mode(mode)
-      previous = Thread.current.thread_variable_get(:queue_bus_local_mode)
-      Thread.current.thread_variable_set(:queue_bus_local_mode, Wrap.new(mode))
+      previous = Thread.current.thread_variable_get(LOCAL_MODE_VAR)
+      Thread.current.thread_variable_set(LOCAL_MODE_VAR, Wrap.new(mode))
       yield if block_given?
     ensure
-      Thread.current.thread_variable_set(:queue_bus_local_mode, previous)
+      Thread.current.thread_variable_set(LOCAL_MODE_VAR, previous)
     end
 
     def adapter=(val)

--- a/spec/config_spec.rb
+++ b/spec/config_spec.rb
@@ -26,6 +26,32 @@ describe 'QueueBus config' do
     expect(QueueBus.local_mode).to eq(:standalone)
   end
 
+  describe '#with_local_mode' do
+    it 'sets the local mode on the thread' do
+      QueueBus.with_local_mode(:suppress) do
+        expect(QueueBus.local_mode).to eq :suppress
+        Thread.new { expect(QueueBus.local_mode).to eq nil }.join
+      end
+    end
+
+    it 'supports nesting' do
+      QueueBus.with_local_mode(:suppress) do
+        expect(QueueBus.local_mode).to eq :suppress
+        QueueBus.with_local_mode(:inline) do
+          expect(QueueBus.local_mode).to eq :inline
+        end
+        expect(QueueBus.local_mode).to eq :suppress
+      end
+    end
+
+    it 'resets to the original local mode after the block' do
+      QueueBus.with_local_mode(:suppress) do
+        expect(QueueBus.local_mode).to eq :suppress
+      end
+      expect(QueueBus.local_mode).to eq nil
+    end
+  end
+
   it 'sets the hostname' do
     expect(QueueBus.hostname).not_to eq(nil)
     QueueBus.hostname = 'whatever'

--- a/spec/config_spec.rb
+++ b/spec/config_spec.rb
@@ -44,6 +44,14 @@ describe 'QueueBus config' do
       end
     end
 
+    it 'respects an override of nil' do
+      QueueBus.local_mode = :suppress
+      QueueBus.with_local_mode(nil) do
+        expect(QueueBus.local_mode).to eq nil
+      end
+      QueueBus.local_mode = :suppress
+    end
+
     it 'resets to the original local mode after the block' do
       QueueBus.with_local_mode(:suppress) do
         expect(QueueBus.local_mode).to eq :suppress


### PR DESCRIPTION
Previously, changing the configuration for local_mode would result in
the setting changing for all threads. This caused issues when run in
sidekiq because there can be multiple threads performing work at the
same time.

Now, there is a new method (with_local_mode) which will execute a block
with a particular local mode. The value is stored on a thread local
variable so that it does not bleed into other executions.