### PR TITLE
Fixes `with_local_mode` for ruby < 2.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- `with_local_mode` breaks subsequent calls to `local_mode` on versions less than 2.6.
+
 ## [0.8.0]
 
 ### Added

--- a/lib/queue_bus/config.rb
+++ b/lib/queue_bus/config.rb
@@ -27,7 +27,7 @@ module QueueBus
 
     # Returns the current local mode of QueueBus
     def local_mode
-      if Thread.current.thread_variable?(LOCAL_MODE_VAR)
+      if Thread.current.thread_variable_get(LOCAL_MODE_VAR).is_a?(Wrap)
         Thread.current.thread_variable_get(LOCAL_MODE_VAR).value
       else
         @local_mode

--- a/spec/config_spec.rb
+++ b/spec/config_spec.rb
@@ -53,6 +53,7 @@ describe 'QueueBus config' do
     end
 
     it 'resets to the original local mode after the block' do
+      expect(QueueBus.local_mode).to eq nil
       QueueBus.with_local_mode(:suppress) do
         expect(QueueBus.local_mode).to eq :suppress
       end


### PR DESCRIPTION
In ruby 2.6, the thread variables get deleted if set to nil. However, in
older versions of ruby this appears to not be the case. This patch
changes the behavior so that we use the type of the value to determine
if we should use it or fall back to the instance variable. This works in
2.6 and 2.5