### PR TITLE
Fix method to return timestamp as minutes since epoch in dev & test

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 - Ran the rubocop autocorrect on the entire codebase.
+- Fixed issue that prevented heartbeat events from firing under certain conditions
 
 ## [0.9.0]
 

--- a/lib/queue_bus/heartbeat.rb
+++ b/lib/queue_bus/heartbeat.rb
@@ -55,7 +55,7 @@ module QueueBus
         case environment_name
         when 'development', 'test'
           # only 3 minutes in development; otherwise, TONS of events if not run in a while
-          three_ago = Time.now.to_i - 3 * 60 * 60
+          three_ago = Time.now.to_i / 60 - 3
           key = three_ago if key.to_i < three_ago
         end
         key.to_i


### PR DESCRIPTION
It seems like this method https://github.com/queue-bus/queue-bus/blob/master/lib/queue_bus/heartbeat.rb#L50 returns "seconds since epoch" instead of "minutes since epoch" in dev & test environments. As a result, heartbeat events are not really fired on local.

I'm intentionally not adding any tests, as there is already a failing test that is fixed by this change.