### PR TITLE
Allow unsubscribing from individual queues

### DIFF
--- a/lib/queue_bus/application.rb
+++ b/lib/queue_bus/application.rb
@@ -32,6 +32,7 @@ module QueueBus
 
       ::QueueBus.redis do |redis|
         redis_hash = subscription_list.to_redis
+
         redis_hash.each do |key, hash|
           redis.hset(temp_key, key, QueueBus::Util.encode(hash))
         end
@@ -46,8 +47,17 @@ module QueueBus
       true
     end
 
+    def unsubscribe_queue(queue)
+      # Filters out all subscriptions that match the supplied queue name.
+      ::QueueBus.redis do |redis|
+        read_redis_hash.each do |key, hash_details|
+          redis.hdel(redis_key, key) if queue == hash_details["queue_name"]
+        end
+      end
+    end
+
     def unsubscribe
-      # TODO: clean up known queues?
+      # Remove everything.
       ::QueueBus.redis do |redis|
         redis.srem(self.class.app_list_key, app_key)
         redis.del(redis_key)

--- a/lib/queue_bus/subscription_list.rb
+++ b/lib/queue_bus/subscription_list.rb
@@ -46,6 +46,12 @@ module QueueBus
       @subscriptions[sub.key] = sub
     end
 
+    def remove(sub)
+      raise "Key #{sub.key} doesn't exist in the #{sub.queue_name} queue!" unless @subscriptions.key?(sub.key)
+
+      @subscriptions.delete(sub.key)
+    end
+
     def size
       @subscriptions.size
     end

--- a/lib/queue_bus/subscription_list.rb
+++ b/lib/queue_bus/subscription_list.rb
@@ -46,12 +46,6 @@ module QueueBus
       @subscriptions[sub.key] = sub
     end
 
-    def remove(sub)
-      raise "Key #{sub.key} doesn't exist in the #{sub.queue_name} queue!" unless @subscriptions.key?(sub.key)
-
-      @subscriptions.delete(sub.key)
-    end
-
     def size
       @subscriptions.size
     end

--- a/lib/queue_bus/task_manager.rb
+++ b/lib/queue_bus/task_manager.rb
@@ -24,6 +24,13 @@ module QueueBus
       count
     end
 
+    def unsubscribe_queue!(app_key, queue)
+      log "Unsubcribing #{queue} from #{app_key}"
+      app = ::QueueBus::Application.new(app_key)
+      app.unsubscribe_queue(queue)
+      log "  ...done"
+    end
+
     def unsubscribe!
       count = 0
       ::QueueBus.dispatchers.each do |dispatcher|

--- a/lib/queue_bus/tasks.rb
+++ b/lib/queue_bus/tasks.rb
@@ -12,11 +12,19 @@ namespace :queuebus do
     raise 'No subscriptions created' if count == 0
   end
 
-  desc 'Unsubscribes this application from QueueBus events'
-  task unsubscribe: [:preload] do
+  desc "Unsubscribes this application from QueueBus events"
+  task :unsubscribe, [:app_key, :queue] => [ :preload ] do |task, args|
+    app_key = args[:app_key]
+    queue = args[:queue]
     manager = ::QueueBus::TaskManager.new(true)
-    count = manager.unsubscribe!
-    puts 'No subscriptions unsubscribed' if count == 0
+
+    if app_key && queue
+      manager.unsubscribe_queue!(app_key, queue)
+    else
+      manager = ::QueueBus::TaskManager.new(true)
+      count = manager.unsubscribe!
+      puts "No subscriptions unsubscribed" if count == 0
+    end
   end
 
   desc 'List QueueBus queues that need worked'

--- a/spec/application_spec.rb
+++ b/spec/application_spec.rb
@@ -102,16 +102,57 @@ module QueueBus
       end
     end
 
-    describe '#unsubscribe' do
-      it 'should remove items' do
-        QueueBus.redis { |redis| redis.sadd('bus_apps', 'myapp') }
-        QueueBus.redis { |redis| redis.sadd('bus_apps', 'other') }
-        QueueBus.redis { |redis| redis.hset('bus_app:myapp', 'event_one', 'myapp_default') }
+    describe "#unsubscribe" do
+      context "when a queue is not specified" do
+        it "removes all subscriptions" do
+          myapp_list = SubscriptionList.new
+          other_list = SubscriptionList.new
 
-        Application.new('myapp').unsubscribe
+          subscription_1 = Subscription.new("myapp_default", "key1", "MyClass1", {"bus_event_type" => "event_one"})
+          subscription_2 = Subscription.new("myapp_default", "key2", "MyClass2", {"bus_event_type" => "event_two"})
+          subscription_3 = Subscription.new("myapp_other_queue", "key1", "MyClass1", {"bus_event_type" => "event_one"})
 
-        expect(QueueBus.redis { |redis| redis.smembers('bus_apps') }).to eq(['other'])
-        expect(QueueBus.redis { |redis| redis.get('bus_app:myapp') }).to be_nil
+          myapp_list.add(subscription_1)
+          myapp_list.add(subscription_2)
+          other_list.add(subscription_3)
+
+          Application.new("myapp").subscribe(myapp_list)
+          Application.new("other").subscribe(other_list)
+
+          expect(QueueBus.redis { |redis| redis.hgetall("bus_app:myapp") }).to eq({
+            "key1" => "{\"queue_name\":\"myapp_default\",\"key\":\"key1\",\"class\":\"MyClass1\",\"matcher\":{\"bus_event_type\":\"event_one\"}}",
+            "key2" => "{\"queue_name\":\"myapp_default\",\"key\":\"key2\",\"class\":\"MyClass2\",\"matcher\":{\"bus_event_type\":\"event_two\"}}"
+          })
+
+          Application.new("myapp").unsubscribe
+
+          expect(QueueBus.redis { |redis| redis.smembers("bus_apps") }).to eq(["other"])
+          expect(QueueBus.redis { |redis| redis.hlen("bus_app:myapp") }).to eq(0)
+        end
+      end
+
+      context "when a queue is specified" do
+        it "removes only that key" do
+          list = SubscriptionList.new
+
+          subscription_1 = Subscription.new("myapp_default", "key1", "MyClass1", {"bus_event_type" => "event_one"})
+          subscription_2 = Subscription.new("myapp_other_queue", "key2", "MyClass2", {"bus_event_type" => "event_two"})
+
+          list.add(subscription_1)
+          list.add(subscription_2)
+
+          Application.new("myapp").subscribe(list)
+
+          expect(QueueBus.redis { |redis| redis.hgetall("bus_app:myapp") }).to eq({
+            "key1" => "{\"queue_name\":\"myapp_default\",\"key\":\"key1\",\"class\":\"MyClass1\",\"matcher\":{\"bus_event_type\":\"event_one\"}}",
+            "key2" => "{\"queue_name\":\"myapp_other_queue\",\"key\":\"key2\",\"class\":\"MyClass2\",\"matcher\":{\"bus_event_type\":\"event_two\"}}"
+          })
+
+          Application.new("myapp").unsubscribe_queue("myapp_default")
+
+          expect(QueueBus.redis { |redis| redis.smembers("bus_apps") }).to eq(["myapp"])
+          expect(QueueBus.redis { |redis| redis.hgetall("bus_app:myapp") }).to eq({"key2" => "{\"queue_name\":\"myapp_other_queue\",\"key\":\"key2\",\"class\":\"MyClass2\",\"matcher\":{\"bus_event_type\":\"event_two\"}}"})
+        end
       end
     end
 

--- a/spec/application_spec.rb
+++ b/spec/application_spec.rb
@@ -128,6 +128,7 @@ module QueueBus
 
           expect(QueueBus.redis { |redis| redis.smembers("bus_apps") }).to eq(["other"])
           expect(QueueBus.redis { |redis| redis.hlen("bus_app:myapp") }).to eq(0)
+          expect(QueueBus.redis { |redis| redis.hlen("bus_app:other") }).to eq(1)
         end
       end
 

--- a/spec/subscription_list_spec.rb
+++ b/spec/subscription_list_spec.rb
@@ -73,25 +73,6 @@ module QueueBus
           expect { list.add(subscription_1) }.to raise_exception(RuntimeError, /Duplicate key/)
         end
       end
-
-      context "when removing subscriptions" do
-        it "removes the subscription successfully" do
-          list.add(subscription_1)
-          list.add(subscription_2)
-
-          list.remove(subscription_1)
-
-          expect(list.to_redis).to eq(
-            {
-              "key2" => {"queue_name" => "else_ok", "key" => "key2", "class" => "MyClass", "matcher" => {"bus_event_type" => "event_two"}},
-            }
-          )
-        end
-
-        it "errors if the subscription can't be found" do
-          expect { list.remove(Subscription.new("other_sub", "other_key", "other_class", {})) }.to raise_exception(RuntimeError, /doesn't exist/)
-        end
-      end
     end
   end
 end

--- a/spec/subscription_list_spec.rb
+++ b/spec/subscription_list_spec.rb
@@ -48,5 +48,50 @@ module QueueBus
                            'key2' => { 'queue_name' => 'else_ok', 'key' => 'key2', 'class' => 'MyClass', 'matcher' => { 'bus_event_type' => 'event_two' } })
       end
     end
+
+    context "when modifying the subscription" do
+      let(:list) { SubscriptionList.new }
+      let(:subscription_1) { Subscription.new("default", "key1", "MyClass", {"bus_event_type" => "event_one"}) }
+      let(:subscription_2) { Subscription.new("else_ok", "key2", "MyClass", {"bus_event_type" => "event_two"}) }
+
+      context "when adding subscriptions" do
+        it "adds the subscription successfully" do
+          list.add(subscription_1)
+          list.add(subscription_2)
+
+          expect(list.to_redis).to eq(
+            {
+              "key1" => {"queue_name" => "default", "key" => "key1", "class" => "MyClass", "matcher" => {"bus_event_type" => "event_one"}},
+              "key2" => {"queue_name" => "else_ok", "key" => "key2", "class" => "MyClass", "matcher" => {"bus_event_type" => "event_two"}}
+            }
+          )
+        end
+
+        it "errors if the subscription already exists" do
+          list.add(subscription_1)
+
+          expect { list.add(subscription_1) }.to raise_exception(RuntimeError, /Duplicate key/)
+        end
+      end
+
+      context "when removing subscriptions" do
+        it "removes the subscription successfully" do
+          list.add(subscription_1)
+          list.add(subscription_2)
+
+          list.remove(subscription_1)
+
+          expect(list.to_redis).to eq(
+            {
+              "key2" => {"queue_name" => "else_ok", "key" => "key2", "class" => "MyClass", "matcher" => {"bus_event_type" => "event_two"}},
+            }
+          )
+        end
+
+        it "errors if the subscription can't be found" do
+          expect { list.remove(Subscription.new("other_sub", "other_key", "other_class", {})) }.to raise_exception(RuntimeError, /doesn't exist/)
+        end
+      end
+    end
   end
 end


### PR DESCRIPTION
## Problem

Sometimes we want to unsubscribe from a specific queue without unsubscribing from an entire application.

## Solution

Add in the concept to look through existing queues and unsubscribe from ones that match a certain name. Also builds in a rake task to make this to do from the command line (format: `rake queuebus:unsubscribe[app_key, queue]`).