### PR TITLE
Optimizes looking up all applications

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Changed
+- Pipelines fetching all queue subscriptions when using `QueueBus::Application.all`
+
 ## [0.11.0]
 
 ### Added


### PR DESCRIPTION
Routinely, we load all applications and then load their individual data
hashes to get the subscriptions. This creates an N+1 number of requests
when dispatching requests. Pipelining should minimize network traffic.