### PR TITLE
Adds a helper for declaring heartbeat subscriptions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- Adds `Dispatch#on_heartbeatch` which is a helper function for specifying heartbeat subscriptions.
+- Adds `Dispatch#on_heartbeat` which is a helper function for specifying heartbeat subscriptions.
 
 ## [0.12.0]
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Adds `Dispatch#on_heartbeatch` which is a helper function for specifying heartbeat subscriptions.
+
 ## [0.12.0]
 
 ### Changed

--- a/README.mdown
+++ b/README.mdown
@@ -63,6 +63,16 @@ QueueBus.dispatch("app_b") do
   subscribe "my_key", { "user_id" => :present, "page" => "homepage"} do
     Mixpanel.homepage_action!(attributes["action"])
   end
+
+  # You may also declare a subscription to heartbeat events. This is a helper function
+  # that works along with subscribe to make scheduling regular events easier.
+  #
+  #   minute_interval: Executes every n minutes
+  #   hour_interval:   Executes every n hours
+  #   minute:          Executes on this minute
+  #   hour:            Executes on this hour
+  on_heartbeat "my_heartbeat_event", minute_interval: 5 do |attributes|
+  end
 end
 ```
 


### PR DESCRIPTION
At TaskRabbit, we use the heartbeat to schedule regular work. This has
resulted in a fairly fragmented implementation of the modulo and
matching logic. By wrapping this in a helper function we can more easily
search and grep for these subscriptions.