### PR TITLE
Fixes the values used by the interval helper

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixes
+
+- Fixes the math used in the heartbeat helper by properly converting it to an integer.
+
 ## [0.13.0]
 
 ### Added

--- a/lib/queue_bus/dispatch.rb
+++ b/lib/queue_bus/dispatch.rb
@@ -40,8 +40,8 @@ module QueueBus
       end
 
       subscribe(key, matcher) do |event|
-        if (minute_interval.nil? || (event['minute'] % minute_interval).zero?) &&
-           (hour_interval.nil? || (event['hour'] % hour_interval).zero?)
+        if (minute_interval.nil? || (event['minute'].to_i % minute_interval).zero?) &&
+           (hour_interval.nil?   || (event['hour'].to_i   % hour_interval).zero?)
 
           # Yield the block passed in.
           block.call

--- a/spec/dispatch_spec.rb
+++ b/spec/dispatch_spec.rb
@@ -44,9 +44,7 @@ module QueueBus
           (0..24).each do |hour|
             (0..60).each do |minute|
               expect do
-                dispatch.execute(
-                  event_name, event.merge('hour' => hour, 'minute' => minute)
-                )
+                dispatch.execute(event_name, event.merge('hour' => hour.to_s, 'minute' => minute.to_s))
               end.to change(Runner2, :value).by(1)
             end
           end
@@ -100,10 +98,10 @@ module QueueBus
         it 'runs the runner when the minute buzzes (modulos to 5)' do
           (0..60).each do |minute|
             if minute % 5 == 0
-              expect { dispatch.execute(event_name, event.merge('minute' => minute)) }
+              expect { dispatch.execute(event_name, event.merge('minute' => minute.to_s)) }
                 .to change(Runner2, :value).by(1)
             else
-              expect { dispatch.execute(event_name, event.merge('minute' => minute)) }
+              expect { dispatch.execute(event_name, event.merge('minute' => minute.to_s)) }
                 .not_to change(Runner2, :value)
             end
           end
@@ -120,10 +118,10 @@ module QueueBus
         it 'runs the runner when the hour fizzes (modulos to 3)' do
           (0..60).each do |hour|
             if hour % 3 == 0
-              expect { dispatch.execute(event_name, event.merge('hour' => hour)) }
+              expect { dispatch.execute(event_name, event.merge('hour' => hour.to_s)) }
                 .to change(Runner2, :value).by(1)
             else
-              expect { dispatch.execute(event_name, event.merge('hour' => hour)) }
+              expect { dispatch.execute(event_name, event.merge('hour' => hour.to_s)) }
                 .not_to change(Runner2, :value)
             end
           end
@@ -142,9 +140,8 @@ module QueueBus
             (0..60).each do |minute|
               if hour % 3 == 0 && minute % 5 == 0
                 expect do
-                  dispatch.execute(
-                    event_name, event.merge('hour' => hour, 'minute' => minute)
-                  )
+                  dispatch.execute(event_name,
+                                   event.merge('hour' => hour.to_s, 'minute' => minute.to_s))
                 end.to change(Runner2, :value).by(1)
               else
                 expect do


### PR DESCRIPTION
Didn't occur to me that these needed to be strings for the comparison to work correctly.