### PR TITLE
Passes the attributes to the heartbeat subscription

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixes
+
+- Properly passes the attributes down to the subscription when using `on_heartbeat`
+
 ## [0.13.1]
 
 ### Fixes

--- a/lib/queue_bus/dispatch.rb
+++ b/lib/queue_bus/dispatch.rb
@@ -50,7 +50,7 @@ module QueueBus
            (hour_interval.nil? || (event['hour'] % hour_interval).zero?)
 
           # Yield the block passed in.
-          block.call
+          block.call(event)
         end
       end
     end

--- a/spec/dispatch_spec.rb
+++ b/spec/dispatch_spec.rb
@@ -33,6 +33,14 @@ module QueueBus
       let(:event) { { bus_event_type: :heartbeat_minutes } }
       let(:event_name) { 'my-event' }
 
+      it 'passes on the event' do
+        dispatch.on_heartbeat event_name do |event|
+          expect(event).to match hash_including('hour' => 1, 'minute' => 0)
+        end
+
+        dispatch.execute(event_name, 'hour' => 1, 'minute' => 0)
+      end
+
       context 'when not declaring anything' do
         before do
           dispatch.on_heartbeat event_name do |_event|


### PR DESCRIPTION
Previously this was passing a nil which is not expected behavior. Now
it's properly passing the event object down.